### PR TITLE
5.0.1 Post Update Optimizations

### DIFF
--- a/AI/AIState.cs
+++ b/AI/AIState.cs
@@ -87,7 +87,7 @@ namespace LethalBots.AI
 
             this.panikCoroutine = oldState.panikCoroutine;
             this.CurrentEnemy = oldState.CurrentEnemy;
-
+            this.useNoiseMakerCooldown = oldState.useNoiseMakerCooldown;
         }
 
         /// <summary>
@@ -726,6 +726,14 @@ namespace LethalBots.AI
             // If we didn't find any enemies near the exit point, we can use this entrance!
             entranceSafetyCache[entrance] = (true, Time.timeSinceLevelLoad);
             return true;
+        }
+
+        /// <summary>
+        /// Simple helper function to clear the <see cref="entranceSafetyCache"/>
+        /// </summary>
+        public static void ResetEntranceSafetyCache()
+        {
+            entranceSafetyCache.Clear();
         }
 
         /// <summary>

--- a/AI/AIStates/FightEnemyState.cs
+++ b/AI/AIStates/FightEnemyState.cs
@@ -5,7 +5,9 @@ using LethalBots.Enums;
 using LethalBots.Managers;
 using LethalBots.NetworkSerializers;
 using LethalBots.Utils.Helpers;
+using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Unity.Netcode;
@@ -28,7 +30,7 @@ namespace LethalBots.AI.AIStates
         private static readonly AccessTools.FieldRef<PatcherTool, int> anomalyMask = AccessTools.FieldRefAccess<int>(typeof(PatcherTool), "anomalyMask");
         private float attackFOV;
         private bool canHitTarget;
-        private RaycastHit[]? enemyColliders;
+        private RaycastHit[] enemyColliders = null!;
         private Coroutine? currentAttackRoutine;
         private Collider? _enemyCollision;
         private EnemyAI? _lastEnemy;
@@ -499,37 +501,170 @@ namespace LethalBots.AI.AIStates
             PlayerControllerB lethalBotController = npcController.Npc;
             Vector3 toEnemy = targetPos - lethalBotController.gameplayCamera.transform.position;
             float angleToEnemy = Vector3.Angle(lethalBotController.playerEye.forward, toEnemy);
+            enemyColliders ??= new RaycastHit[10];
 
             // Check if we can potentially hit!
             GetWeaponAttackInfo(heldItem, lethalBotController, out Ray ray, out float maxFOV, out float radius, out float maxRange, out LayerMask hitMask);
             attackFOV = Mathf.Clamp(maxFOV, 0f, Const.LETHAL_BOT_FOV);
             if (angleToEnemy < maxFOV)
             {
-                // Check if we hit the target!
-                enemyColliders ??= new RaycastHit[10];
-
-                // Do an initial linecast!
-                if (Physics.Linecast(lethalBotController.gameplayCamera.transform.position, targetPos, StartOfRound.Instance.collidersAndRoomMaskAndDefault))
+                // Choose a checker function based on the weapon!
+                // TODO: Add a function(s) that makes it easier for modders to add custom weapon support!
+                if (heldItem is PatcherTool)
                 {
-                    return false;
+                    return CanHitPatcherTool(lethalBotController, targetPos, ray, radius, maxRange, hitMask);
                 }
-
-                // Now check if we would actually hit based on the weapon's hitmask!
-                int numHit = Physics.SphereCastNonAlloc(ray, radius, enemyColliders, maxRange, hitMask, QueryTriggerInteraction.Collide);
-                for (int i = 0; i < numHit; i++)
+                else if (LethalBotAI.IsItemRangedWeapon(heldItem))
                 {
-                    // Check if we hit the target!
-                    var hitInfo = enemyColliders[i];
-                    if (hitInfo.collider == EnemyCollision
-                        || (hitInfo.collider.gameObject.GetComponentInParent<EnemyAI>() is EnemyAI hitTarget 
-                            && hitTarget == this.CurrentEnemy))
-                    {
-                        return true;
-                    }
+                    return CanHitRangedWeapon(lethalBotController, ray, radius, maxRange, hitMask);
                 }
-
+                else
+                {
+                    return CanHitMeleeWeapon(lethalBotController, ray, radius, maxRange, hitMask);
+                }
             }
 
+            return false;
+        }
+
+        /// <summary>
+        /// Helper function that checks if the bot can hit our <see cref="AIState.CurrentEnemy"/>.
+        /// </summary>
+        /// <remarks>
+        /// This is an almost 1:1 recreation of the <see cref="ShotgunItem.ShootGun(Vector3, Vector3)"/>.
+        /// </remarks>
+        /// <param name="lethalBotController">The bot's <see cref="PlayerControllerB"/></param>
+        /// <param name="ray">The <see cref="Ray"/> we want to assess</param>
+        /// <param name="radius"></param>
+        /// <param name="maxRange"></param>
+        /// <param name="hitMask"></param>
+        /// <returns></returns>
+        private bool CanHitRangedWeapon(PlayerControllerB lethalBotController, Ray ray, float radius, float maxRange, LayerMask hitMask)
+        {
+            // Check if we hit the target based on the weapon's hitmask!
+            int numHit = Physics.SphereCastNonAlloc(ray, radius, enemyColliders, maxRange, hitMask, QueryTriggerInteraction.Collide);
+            for (int i = 0; i < numHit; i++)
+            {
+                // Check if we hit the target!
+                var hitInfo = enemyColliders[i];
+                if (hitInfo.distance == 0f || hitInfo.point == Vector3.zero) continue;
+
+                // // Make sure this is a valid hit target and do an initial linecast!
+                if (!hitInfo.transform.TryGetComponent<IHittable>(out _) || Physics.Linecast(lethalBotController.gameplayCamera.transform.position, hitInfo.point, StartOfRound.Instance.collidersAndRoomMaskAndDefault, QueryTriggerInteraction.Ignore))
+                {
+                    continue;
+                }
+
+                // Check if we hit the target!
+                if (hitInfo.collider == EnemyCollision
+                    || (hitInfo.transform.gameObject.GetComponent<EnemyAICollisionDetect>()?.mainScript is EnemyAI hitTarget
+                        && hitTarget == this.CurrentEnemy))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Helper function that checks if the bot can hit our <see cref="AIState.CurrentEnemy"/>.
+        /// </summary>
+        /// <remarks>
+        /// This is a partial recreation of the <see cref="PatcherTool"/>'s ScanGun and GunMeetsConditionsToShock.
+        /// </remarks>
+        /// <param name="lethalBotController">The bot's <see cref="PlayerControllerB"/></param>
+        /// <param name="ray">The <see cref="Ray"/> we want to assess</param>
+        /// <param name="targetPos"></param>
+        /// <param name="radius"></param>
+        /// <param name="maxRange"></param>
+        /// <param name="hitMask"></param>
+        /// <returns></returns>
+        private bool CanHitPatcherTool(PlayerControllerB lethalBotController, Vector3 targetPos, Ray ray, float radius, float maxRange, LayerMask hitMask)
+        {
+            // Check if we hit the target!
+            enemyColliders ??= new RaycastHit[10];
+
+            // Do an initial linecast!
+            if (Physics.Linecast(lethalBotController.gameplayCamera.transform.position, targetPos, StartOfRound.Instance.collidersAndRoomMaskAndDefault))
+            {
+                return false;
+            }
+
+            // Now check if we would actually hit based on the weapon's hitmask!
+            int numHit = Physics.SphereCastNonAlloc(ray, radius, enemyColliders, maxRange, hitMask, QueryTriggerInteraction.Collide);
+            for (int i = 0; i < numHit; i++)
+            {
+                // Check if we hit the target!
+                var hitInfo = enemyColliders[i];
+                if (hitInfo.collider == EnemyCollision
+                    || (hitInfo.collider.gameObject.GetComponentInParent<EnemyAI>() is EnemyAI hitTarget
+                        && hitTarget == this.CurrentEnemy))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Helper function that checks if the bot can hit our <see cref="AIState.CurrentEnemy"/>.
+        /// </summary>
+        /// <remarks>
+        /// This is an almost 1:1 recreation of the <see cref="Shovel.HitShovel(bool)"/> and <see cref="KnifeItem.HitKnife(bool)"/>.
+        /// </remarks>
+        /// <param name="lethalBotController">The bot's <see cref="PlayerControllerB"/></param>
+        /// <param name="ray">The <see cref="Ray"/> we want to assess</param>
+        /// <param name="radius"></param>
+        /// <param name="maxRange"></param>
+        /// <param name="hitMask"></param>
+        /// <returns></returns>
+        private bool CanHitMeleeWeapon(PlayerControllerB lethalBotController, Ray ray, float radius, float maxRange, LayerMask hitMask)
+        {
+            // Check if we hit the target based on the weapon's hitmask!
+            RaycastHit[] raycastHits = Physics.SphereCastAll(ray, radius, maxRange, hitMask, QueryTriggerInteraction.Collide);
+            List<RaycastHit> orderdHitList = raycastHits.OrderBy((RaycastHit x) => x.distance).ToList();
+            foreach (var hitInfo in raycastHits)
+            {
+                // Check if we hit a wall!
+                if (hitInfo.transform.gameObject.layer == 8 || hitInfo.transform.gameObject.layer == 11)
+                {
+                    if (hitInfo.collider.isTrigger)
+                    {
+                        continue;
+                    }
+                    string text = hitInfo.collider.gameObject.tag;
+                    foreach (var surface in StartOfRound.Instance.footstepSurfaces)
+                    {
+                        if (surface.surfaceTag == text)
+                        {
+                            break;
+                        }
+                    }
+                }
+                else
+                {
+                    // Check if we hit a valid target
+                    if (!hitInfo.transform.TryGetComponent<IHittable>(out var component) || (hitInfo.point != Vector3.zero && Physics.Linecast(lethalBotController.gameplayCamera.transform.position, hitInfo.point, out var _, StartOfRound.Instance.collidersAndRoomMaskAndDefault, QueryTriggerInteraction.Ignore)))
+                    {
+                        continue;
+                    }
+                    Vector3 forward = lethalBotController.gameplayCamera.transform.forward;
+                    EnemyAICollisionDetect component2 = hitInfo.transform.GetComponent<EnemyAICollisionDetect>();
+                    bool isIHittablePlayer = hitInfo.transform.GetComponent<PlayerControllerB>() != null;
+                    if (component2 != null || !isIHittablePlayer)
+                    {
+                        if (!isIHittablePlayer || (component2?.mainScript != null && (!StartOfRound.Instance.hangarDoorsClosed || component2.mainScript.isInsidePlayerShip == lethalBotController.isInHangarShipRoom)))
+                        {
+                            // Check if we hit the target!
+                            if (hitInfo.collider == EnemyCollision
+                                || (component2 != null && component2 == this.CurrentEnemy))
+                            {
+                                return true;
+                            }
+                        }
+                    }
+                }
+            }
             return false;
         }
 

--- a/AI/AIStates/HealPlayerState.cs
+++ b/AI/AIStates/HealPlayerState.cs
@@ -2,6 +2,7 @@
 using HarmonyLib;
 using LethalBots.Constants;
 using LethalBots.Enums;
+using LethalBots.Utils.Helpers;
 using System.Collections;
 using System.Collections.Generic;
 using System.Text;
@@ -17,7 +18,19 @@ namespace LethalBots.AI.AIStates
         private PlayerControllerB healTarget;
         private HealMethod healMethod = HealMethod.None;
         private Coroutine? healCoroutine;
-        private static CadaverGrowthAI? cadaverGrowthAI;
+        private static readonly UpdateLimiter nextCadaverGrowthCheck = new UpdateLimiter();
+        private static CadaverGrowthAI? CadaverGrowthAI
+        {
+            get
+            {
+                if (field == null && nextCadaverGrowthCheck.CanUpdate())
+                {
+                    nextCadaverGrowthCheck.Invalidate();
+                    field = Object.FindObjectOfType<CadaverGrowthAI>();
+                }
+                return field;
+            }
+        }
 
         public HealPlayerState(AIState oldState, PlayerControllerB targetPlayer) : base(oldState)
         {
@@ -152,16 +165,12 @@ namespace LethalBots.AI.AIStates
                 return false; // We can't heal ourselves with weed killer, someone else has to do it for us.
             }
 
-            if (cadaverGrowthAI == null)
+            if (CadaverGrowthAI == null)
             {
-                cadaverGrowthAI = Object.FindObjectOfType<CadaverGrowthAI>();
-                if (cadaverGrowthAI == null)
-                {
-                    //Plugin.LogDebug("HealPlayerState: Cannot find CadaverGrowthAI, cannot heal with weed killer!");
-                    return false;
-                }
+                //Plugin.LogDebug("HealPlayerState: Cannot find CadaverGrowthAI, cannot heal with weed killer!");
+                return false;
             }
-            PlayerInfection playerInfection = cadaverGrowthAI.playerInfections[healTarget.playerClientId];
+            PlayerInfection playerInfection = CadaverGrowthAI.playerInfections[healTarget.playerClientId];
             if (!playerInfection.infected || playerInfection.infectionMeter < requiredInfectionLevel)
             {
                 //Plugin.LogDebug("HealPlayerState: Player is not infected with the Cadaver infection, cannot heal with weed killer!");

--- a/AI/LethalBotAI.cs
+++ b/AI/LethalBotAI.cs
@@ -115,6 +115,7 @@ namespace LethalBots.AI
                 if (dunGenTileTracker == null)
                 {
                     dunGenTileTracker = this.gameObject.GetComponent<DunGenTileTracker>() ?? this.gameObject.AddComponent<DunGenTileTracker>();
+                    dunGenTileTracker.lethalBotAI = this;
                 }
                 return dunGenTileTracker;
             }

--- a/LethalBot.csproj
+++ b/LethalBot.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>LethalBots</AssemblyName>
     <Product>LethalBots</Product>
     <!-- Change to whatever version you're currently on. This will be used by tcli when building our Thunderstore package. -->
-    <Version>5.0.0</Version>
+    <Version>5.0.1</Version>
   </PropertyGroup>
 
   <!-- Project Properties -->

--- a/Managers/LethalBotManager.cs
+++ b/Managers/LethalBotManager.cs
@@ -2817,16 +2817,16 @@ namespace LethalBots.Managers
                     continue;
                 }
 
-                //positionLethalBot = lethalBotAI.NpcController.Npc.transform.position;
-                //if (lethalBotAI.NpcController.Npc.deadBody != null)
-                //{
-                //    positionLethalBot = lethalBotAI.NpcController.Npc.deadBody.bodyParts[5].transform.position;
-                //}
+                Vector3 positionLethalBot = lethalBotAI.NpcController.Npc.transform.position;
+                if (lethalBotAI.NpcController.Npc.deadBody != null)
+                {
+                    positionLethalBot = lethalBotAI.NpcController.Npc.deadBody.bodyParts[5].transform.position;
+                }
 
-                //if ((positionLethalBot - teleporter.teleportOutPosition.position).sqrMagnitude > 2f * 2f)
-                //{
-                //    continue;
-                //}
+                if ((positionLethalBot - teleporter.teleportOutPosition.position).sqrMagnitude > 2f * 2f)
+                {
+                    continue;
+                }
 
                 //if (RoundManager.Instance.insideAINodes.Length == 0)
                 //{
@@ -3570,6 +3570,7 @@ namespace LethalBots.Managers
                 GroupManager.Instance.ResetAndRemoveAllGroups();
             }
             SetLastReportedTimeOfDay(DayMode.Dawn);
+            AIState.ResetEntranceSafetyCache();
 
             if (preRevive)
             {

--- a/Patches/MapPatches/ShipTeleporterPatch.cs
+++ b/Patches/MapPatches/ShipTeleporterPatch.cs
@@ -3,7 +3,13 @@ using HarmonyLib;
 using LethalBots.AI;
 using LethalBots.Constants;
 using LethalBots.Managers;
+using LethalBots.Utils;
 using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
 using UnityEngine;
 using Random = System.Random;
 
@@ -55,6 +61,54 @@ namespace LethalBots.Patches.MapPatches
             {
                 lethalBotAI.InitStateToSearchingNoTarget(true);
             }
+        }
+
+        // I just recently learned that we CAN patch coroutines, you just need to add the MethodType.Enumerator to do so!!!!! :D
+        [HarmonyPatch("beamUpPlayer", MethodType.Enumerator)]
+        [HarmonyTranspiler]
+        public static IEnumerable<CodeInstruction> beamUpPlayer_Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
+        {
+            var startIndex = -1;
+            var codes = new List<CodeInstruction>(instructions);
+
+            // Target property: GameNetworkManager.Instance.localPlayerController
+            MethodInfo getGameNetworkManagerInstance = AccessTools.PropertyGetter(typeof(GameNetworkManager), "Instance");
+            FieldInfo localPlayerControllerField = AccessTools.Field(typeof(GameNetworkManager), "localPlayerController");
+
+            // Unity Object Equality Method
+            MethodInfo opEqualityMethod = AccessTools.Method(typeof(UnityEngine.Object), "op_Equality");
+
+            // ------------------------------------------------
+            for (var i = 0; i < codes.Count - 4; i++)
+            {
+                // NOTE: We cannot access the fields of the coroutine class, we must manually find them instead!
+                if (codes[i].opcode == OpCodes.Ldfld && codes[i].operand is FieldInfo fi && fi.Name.Contains("playerToBeamUp")
+                    && codes[i + 1].Calls(getGameNetworkManagerInstance) // 1588
+                    && codes[i + 2].LoadsField(localPlayerControllerField) // 1589
+                    && codes[i + 3].Calls(opEqualityMethod)) // 1593
+                {
+                    startIndex = i;
+                    break;
+                }
+            }
+            if (startIndex > -1)
+            {
+                // Replace the old GameNetworkManager.Instance.localPlayerController == this.playerToBeamUp check,
+                // and replace it with our IsPlayerLocalOrLethalBotOwnerLocalMethod
+                codes[startIndex + 1].opcode = OpCodes.Nop;
+                codes[startIndex + 1].operand = null;
+                codes[startIndex + 2].opcode = OpCodes.Nop;
+                codes[startIndex + 2].operand = null;
+                codes[startIndex + 3].opcode = OpCodes.Call;
+                codes[startIndex + 3].operand = PatchesUtil.IsPlayerLocalOrLethalBotOwnerLocalMethod;
+                startIndex = -1;
+            }
+            else
+            {
+                Plugin.LogError($"LethalBot.Patches.MapPatches.ShipTeleporterPatch.beamUpPlayer_Transpiler could not make bots drop their held items when teleported");
+            }
+
+            return codes.AsEnumerable();
         }
 
         [HarmonyPatch("SetPlayerTeleporterId")]

--- a/Thunderstore/CHANGELOG.md
+++ b/Thunderstore/CHANGELOG.md
@@ -17,7 +17,7 @@ Mind you the issue gets worse with adding more human players as well.........
 Anyway I also made some other optimizations and bug fixes.
 
 Change Log:
-- Fixed a logic error in FightEnemyState which caused bots to sometimes believe they cannot hit an enemy when they actually could
+- Fixed a logic error in FightEnemyState which caused bots to sometimes believe they cannot hit an enemy when they actually could. (Yes, bots can now properly fight Thumpers again! :confetti_ball:)
 - Fixed a logic error in HealPlayerState that would cause the bots to spam FindObjectOfType calls every time CanHealPlayerWithWeedKiller was called
 - Fixed AIState.useNoiseMakerCooldown not being shared between states which could causes some infinite loops
 - Fixed all bots being teleported by an inverse teleporter even if they were not standing near it

--- a/Thunderstore/CHANGELOG.md
+++ b/Thunderstore/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 5.0.1 - 2026-4-8
+Hello, a minor bug fix patch here. It came to my attention that trying to have more than 3 bots would REALLY lag the game. The cause was a logic error in HealPlayerState that would cause the bots to spam FindObjectOfType calls every time CanHealPlayerWithWeedKiller was called.
+
+Here was how bad the logic error was:
+For context, this was called for every bot for every player in the game other than the bot itself.
+
+For three bots, that's about 3 Bots * 4 Players each. That's around 12 FindObjectOfType calls. Which isn't too bad........
+
+As for 7 bots, that's about 7 Bots * 8 Players each. That's over 56 FindObjectOfType CALLS.........
+
+And for the 15 bots, that's about 15 Bots * 16 Players each. That's OVER 240 FindObjectOfType..... :sob: 
+
+Mind you the issue gets worse with adding more human players as well.........
+
+Anyway I also made some other optimizations and bug fixes.
+
+Change Log:
+- Fixed a logic error in FightEnemyState which caused bots to sometimes believe they cannot hit an enemy when they actually could
+- Fixed a logic error in HealPlayerState that would cause the bots to spam FindObjectOfType calls every time CanHealPlayerWithWeedKiller was called
+- Fixed AIState.useNoiseMakerCooldown not being shared between states which could causes some infinite loops
+- Fixed all bots being teleported by an inverse teleporter even if they were not standing near it
+- Fixed a bug created by the V80 update which caused bots to not drop their held items when teleported back to the ship
+- DunGenTileTracker now keeps track of the LethalBotAI its attached to
+- Added an UpdateLimiter to DunGenTileTracker and had its update rate set the the LethalBotAI's AIIntervalTime so about every 0.3 seconds
+- Added a new function to UpdateLimiter, SetUpdateInterval. This allows me to change updateInterval without having access to the constructor
+- Added some comments to UpdateLimiter
+
 ## 5.0.0 - 2026-4-7
 ITS V81 TIME!!!!!!!<br/>
 Hello again, V81 came out and as such the bots needed to be updated to work with the newest version of Lethal Company. I have also taken the liberty to teach the bots how to counter one of the new enemies, but with a catch. Now onto the patch notes!

--- a/Utils/Helpers/DunGenTileTracker.cs
+++ b/Utils/Helpers/DunGenTileTracker.cs
@@ -3,12 +3,17 @@ using System.Collections.Generic;
 using System.Linq;
 using DunGen;
 using DunGen.Tags;
+using LethalBots.AI;
 using UnityEngine;
 
 namespace LethalBots.Utils.Helpers
 {
     public class DunGenTileTracker : MonoBehaviour
     {
+        private readonly UpdateLimiter updateLimiter = new UpdateLimiter();
+
+        public LethalBotAI lethalBotAI { get; internal set; } = null!;
+
         public int AdjacentTileDepth = 1;
 
         public bool CullBehindClosedDoors = true;
@@ -236,8 +241,19 @@ namespace LethalBots.Utils.Helpers
 
         protected virtual void LateUpdate()
         {
-            if (Ready)
+            if (Ready && updateLimiter.CanUpdate())
             {
+                // Reset the update limiter
+                updateLimiter.SetUpdateInterval(lethalBotAI.AIIntervalTime);
+                updateLimiter.Invalidate();
+
+                // Don't do this if we are not inside
+                if (!lethalBotAI.NpcController.Npc.isInsideFactory)
+                {
+                    return;
+                }
+
+                // Check what tile we are on
                 Tile? tile = currentTile;
                 if (currentTile == null)
                 {

--- a/Utils/Helpers/UpdateLimiter.cs
+++ b/Utils/Helpers/UpdateLimiter.cs
@@ -47,12 +47,29 @@ namespace LethalBots.Utils.Helpers
             this.Invalidate();
         }
 
+        /// <summary>
+        /// Changes the update interval for this <see cref="UpdateLimiter"/>
+        /// </summary>
+        /// <param name="updateInterval"></param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void SetUpdateInterval(float updateInterval)
+        {
+            this.updateInterval = updateInterval;
+        }
+
+        /// <summary>
+        /// Has our <see cref="updateInterval"/> elapsed
+        /// </summary>
+        /// <returns></returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool CanUpdate()
         {
             return !nextUpdateTimer.HasStarted() || nextUpdateTimer.Elapsed();
         }
 
+        /// <summary>
+        /// Restarts our update limiter by using our set <see cref="updateInterval"/>
+        /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Invalidate()
         {


### PR DESCRIPTION
Hello, a minor bug fix patch here. It came to my attention that trying to have more than 3 bots would REALLY lag the game. The cause was a logic error in HealPlayerState that would cause the bots to spam FindObjectOfType calls every time CanHealPlayerWithWeedKiller was called.

Here was how bad the logic error was:
For context, this was called for every bot for every player in the game other than the bot itself.

For three bots, that's about 3 Bots * 4 Players each. That's around 12 FindObjectOfType calls. Which isn't too bad........

As for 7 bots, that's about 7 Bots * 8 Players each. That's over 56 FindObjectOfType CALLS.........

And for the 15 bots, that's about 15 Bots * 16 Players each. That's OVER 240 FindObjectOfType..... :sob: 

Mind you the issue gets worse with adding more human players as well.........

Anyway I also made some other optimizations and bug fixes.

Change Log:
- Fixed a logic error in FightEnemyState which caused bots to sometimes believe they cannot hit an enemy when they actually could. (Yes, bots can now properly fight Thumpers again! :confetti_ball:)
- Fixed a logic error in HealPlayerState that would cause the bots to spam FindObjectOfType calls every time CanHealPlayerWithWeedKiller was called
- Fixed AIState.useNoiseMakerCooldown not being shared between states which could causes some infinite loops
- Fixed all bots being teleported by an inverse teleporter even if they were not standing near it
- Fixed a bug created by the V80 update which caused bots to not drop their held items when teleported back to the ship
- DunGenTileTracker now keeps track of the LethalBotAI its attached to
- Added an UpdateLimiter to DunGenTileTracker and had its update rate set the the LethalBotAI's AIIntervalTime so about every 0.3 seconds
- Added a new function to UpdateLimiter, SetUpdateInterval. This allows me to change updateInterval without having access to the constructor
- Added some comments to UpdateLimiter