### PR TITLE
6.1.1 Bug Fixes

### DIFF
--- a/AI/AIStates/BrainDeadState.cs
+++ b/AI/AIStates/BrainDeadState.cs
@@ -24,7 +24,6 @@ namespace LethalBots.AI.AIStates
             // Don't need to do the rest of the logic if we already voted to leave!
             StartOfRound instanceSOR = StartOfRound.Instance;
             if (hasVotedToLeave 
-                || LethalBotManager.AreWeInOrbit(instanceSOR)
                 || LethalBotManager.IsTheShipLeaving(instanceSOR)
                 || TimeOfDay.Instance.shipLeavingAlertCalled)
             {
@@ -49,6 +48,12 @@ namespace LethalBots.AI.AIStates
                 {
                     ai.State = ai.GetDesiredAIState();
                 }
+                return;
+            }
+
+            // Don't run our voting code if we are in orbit
+            if (LethalBotManager.AreWeInOrbit(instanceSOR))
+            {
                 return;
             }
 

--- a/AI/LethalBotAI.cs
+++ b/AI/LethalBotAI.cs
@@ -8078,7 +8078,7 @@ namespace LethalBots.AI
         /// Makes the bot leave the terminal, this has proper support for animations!
         /// </summary>
         /// <param name="syncTerminalInUse">Should the terminal update its status on all clients?</param>
-        public void LeaveTerminal(bool syncTerminalInUse = true)
+        public void LeaveTerminal(bool syncTerminalInUse = true, bool forceEndUse = false)
         {
             // Terminal is invalid for some reason, report the error!
             Terminal ourTerminal = Managers.TerminalManager.Instance.GetTerminal();
@@ -8091,7 +8091,7 @@ namespace LethalBots.AI
             }
 
             PlayerControllerB localPlayerController = NpcController.Npc;
-            if (!localPlayerController.inTerminalMenu)
+            if (!localPlayerController.inTerminalMenu && !forceEndUse)
             {
                 Plugin.LogWarning($"Bot {localPlayerController.playerUsername} was told to leave a terminal when they were not using it!");
                 return;

--- a/AI/LethalBotAI.cs
+++ b/AI/LethalBotAI.cs
@@ -467,6 +467,16 @@ namespace LethalBots.AI
                     State = new BrainDeadState(this);
                 }
 
+                // If the bot is using a terminal and is not in a state that needs it,
+                // they should leave the terminal
+                if (!State.CheckAllowsTerminalUse())
+                {
+                    if (NpcController.Npc.inTerminalMenu)
+                    {
+                        LeaveTerminal();
+                    }
+                }
+
                 // No AI calculation if in special animation if climbing ladder or inSpecialInteractAnimation
                 if (!NpcController.Npc.isClimbingLadder && !NpcController.Npc.inTerminalMenu
                     && (NpcController.Npc.inSpecialInteractAnimation || NpcController.Npc.enteringSpecialAnimation))
@@ -9570,9 +9580,8 @@ namespace LethalBots.AI
                 suitID = 0;
             }
 
-            UnlockableItem unlockableItem = StartOfRound.Instance.unlockablesList.unlockables[suitID];
-            if (!unlockableItem.hasBeenUnlockedByPlayer 
-                && !unlockableItem.alreadyUnlocked)
+            // Do we own the suit?
+            if (!LethalBotIdentity.IsSuitOwned(suitID))
             {
                 return;
             }

--- a/AI/LethalBotIdentity.cs
+++ b/AI/LethalBotIdentity.cs
@@ -124,5 +124,28 @@ namespace LethalBots.AI
 
             return indexesSpawnedUnlockables[randomIndex];
         }
+
+        /// <summary>
+        /// Helper function that checks if the crew owns the given suit!
+        /// </summary>
+        /// <param name="suitID"></param>
+        /// <returns></returns>
+        public bool IsSuitOwned(int suitID)
+        {
+            // Check if the crew already unlocked the suit
+            UnlockableItem unlockableItem = StartOfRound.Instance.unlockablesList.unlockables[suitID];
+            if (!unlockableItem.hasBeenUnlockedByPlayer
+                && !unlockableItem.alreadyUnlocked
+                && (!StartOfRound.Instance.isChallengeFile || !unlockableItem.unlockedInChallengeFile))
+            {
+                // Some custom suit mods just add a spawned unlockable, check if it exists!
+                if (!StartOfRound.Instance.SpawnedShipUnlockables.TryGetValue(suitID, out var gameObject) 
+                    || gameObject == null)
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
     }
 }

--- a/LethalBot.csproj
+++ b/LethalBot.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>LethalBots</AssemblyName>
     <Product>LethalBots</Product>
     <!-- Change to whatever version you're currently on. This will be used by tcli when building our Thunderstore package. -->
-    <Version>6.1.0</Version>
+    <Version>6.1.1</Version>
   </PropertyGroup>
 
   <!-- Project Properties -->

--- a/Managers/LethalBotManager.cs
+++ b/Managers/LethalBotManager.cs
@@ -1385,8 +1385,10 @@ namespace LethalBots.Managers
             //lethalBotAI.transform.parent = objectParent.transform;
             //lethalBotAI.NetworkObject.AutoObjectParentSync = true;
             lethalBotAI.enabled = true;
-
-            objectParent.SetActive(true);
+            if (clientJoining && lethalBotController.currentlyHeldObject != null)
+            {
+                lethalBotAI.HeldItem = lethalBotController.currentlyHeldObject;
+            }
 
             // Unsuscribe from events to prevent double trigger
             PlayerControllerBPatch.OnDisable_ReversePatch(lethalBotController);
@@ -1726,8 +1728,8 @@ namespace LethalBots.Managers
                     lethalBotAI.State = new BrainDeadState(lethalBotAI);
                 }
 
-                lethalBotController.TeleportPlayer(lethalBotController.playersManager.notSpawnedPosition.position);
-                lethalBotController.localVisor.position = lethalBotController.playersManager.notSpawnedPosition.position;
+                lethalBotController.TeleportPlayer(instanceSOR.notSpawnedPosition.position);
+                lethalBotController.localVisor.position = instanceSOR.notSpawnedPosition.position;
                 lethalBotController.DisablePlayerModel(lethalBotController.gameObject, enable: true, disableLocalArms: true);
 
                 // Reset the animator state
@@ -1738,7 +1740,7 @@ namespace LethalBots.Managers
                     lethalBotAnimator.Update(0f);
                 }
 
-                lethalBotController.transform.position = lethalBotController.playersManager.notSpawnedPosition.position;
+                lethalBotController.transform.position = instanceSOR.notSpawnedPosition.position;
                 lethalBotController.thisController.enabled = false;
                 if (!NetworkManager.Singleton.ShutdownInProgress && base.IsServer)
                 {
@@ -1751,8 +1753,6 @@ namespace LethalBots.Managers
                 {
                     quickMenuManager.RemoveUserFromPlayerList((int)lethalBotController.playerClientId);
                 }
-
-                instanceSOR.allPlayerObjects[lethalBotController.playerClientId].SetActive(false);
 
                 // Finished kicking
                 // HACKHACK: If the bot being kicked was the last living player, the game would softlock since end of round only
@@ -1818,6 +1818,15 @@ namespace LethalBots.Managers
                 if (RoundManager.Instance.playersFinishedGeneratingFloor.Contains(clientId))
                 {
                     RoundManager.Instance.playersFinishedGeneratingFloor.Remove(clientId);
+                }
+
+                // Set the name back to the default for LAN players
+                if (GameNetworkManager.Instance.disableSteam)
+                {
+                    string defaultName = $"Player #{lethalBotController.playerClientId}";
+                    lethalBotController.playerUsername = defaultName;
+                    lethalBotController.usernameBillboardText.text = defaultName;
+                    StartOfRound.Instance.mapScreen.radarTargets[(int)lethalBotController.playerClientId].name = defaultName;
                 }
 
                 // Delete now unused bot object
@@ -3941,9 +3950,9 @@ namespace LethalBots.Managers
                 }
 
                 lethalBotController.isPlayerControlled = false;
-                lethalBotController.TeleportPlayer(lethalBotController.playersManager.notSpawnedPosition.position);
-                lethalBotController.localVisor.position = lethalBotController.playersManager.notSpawnedPosition.position;
-                lethalBotController.DisablePlayerModel(lethalBotController.gameObject, enable: true, disableLocalArms: true);
+                lethalBotController.TeleportPlayer(instanceSOR.notSpawnedPosition.position);
+                lethalBotController.localVisor.position = instanceSOR.notSpawnedPosition.position;
+                lethalBotController.DisablePlayerModel(instanceSOR.allPlayerObjects[lethalBot] ?? lethalBotController.gameObject, enable: true, disableLocalArms: true);
 
                 // HACKHACK: ModelReplacementAPI recreates the body replacement even on disabled player controllers,
                 // we have to mimic what the base game does and switch back to the default suit here!
@@ -3959,7 +3968,7 @@ namespace LethalBots.Managers
                     lethalBotAnimator.Update(0f);
                 }
 
-                lethalBotController.transform.position = lethalBotController.playersManager.notSpawnedPosition.position;
+                lethalBotController.transform.position = instanceSOR.notSpawnedPosition.position;
                 lethalBotController.thisController.enabled = false;
                 if (!NetworkManager.Singleton.ShutdownInProgress && base.IsServer)
                 {
@@ -3984,10 +3993,17 @@ namespace LethalBots.Managers
                 {
                     RoundManager.Instance.playersFinishedGeneratingFloor.Remove(clientId);
                 }
-
-                instanceSOR.allPlayerObjects[lethalBotController.playerClientId].SetActive(false);
                 //instanceSOR.connectedPlayersAmount -= 1;
                 //instanceSOR.livingPlayers -= 1;
+
+                // Set the name back to the default for LAN players
+                if (GameNetworkManager.Instance.disableSteam)
+                {
+                    string defaultName = $"Player #{lethalBot}";
+                    lethalBotController.playerUsername = defaultName;
+                    lethalBotController.usernameBillboardText.text = defaultName;
+                    StartOfRound.Instance.mapScreen.radarTargets[lethalBot].name = defaultName;
+                }
             }
 
             // Clear out the table in case this is called again somehow

--- a/Patches/GameEnginePatches/GameNetworkManagerPatch.cs
+++ b/Patches/GameEnginePatches/GameNetworkManagerPatch.cs
@@ -1,8 +1,10 @@
-﻿using HarmonyLib;
+﻿using GameNetcodeStuff;
+using HarmonyLib;
+using LethalBots.AI;
 using LethalBots.Constants;
 using LethalBots.Managers;
+using LethalBots.Utils;
 using Unity.Netcode;
-using GameNetcodeStuff;
 
 namespace LethalBots.Patches.GameEnginePatches
 {
@@ -20,6 +22,57 @@ namespace LethalBots.Patches.GameEnginePatches
         public static void SaveGame_Postfix()
         {
             SaveManager.Instance.SavePluginInfos();
+        }
+
+        /// <summary>
+        /// If a player leaves the game, have the bots swap their ownership back to the host!
+        /// </summary>
+        /// <param name="__instance"></param>
+        /// <param name="clientId"></param>
+        [HarmonyPatch("Singleton_OnClientDisconnectCallback")]
+        [HarmonyPrefix]
+        static void Singleton_OnClientDisconnectCallback_Prefix(GameNetworkManager __instance, ulong clientId)
+        {
+            // Don't do this if the host disconnects
+            if (NetworkManager.Singleton == null 
+                || clientId == NetworkManager.Singleton.LocalClientId)
+            {
+                return;
+            }
+
+            // Only do this on the server
+            if (NetworkManager.Singleton.IsServer)
+            {
+                // Update the player counts!
+                LethalBotManager.Instance.sendPlayerCountUpdate.Value = true;
+
+                // Change the bot's ownership to the host
+                int playerClientId = -1;
+                if (StartOfRound.Instance.ClientPlayerList.TryGetValue(clientId, out var value))
+                {
+                    playerClientId = (int)StartOfRound.Instance.allPlayerScripts[value].playerClientId;
+                }
+
+                Terminal terminal = TerminalManager.Instance.GetTerminal();
+                InteractTrigger terminalInteractTrigger = PatchesUtil.terminalTriggerField.Invoke(terminal);
+                foreach (LethalBotAI lethalBotAI in LethalBotManager.Instance.GetLethalBotAIs())
+                {
+                    // Check to see if the bot is owned by the disconnecting client
+                    if (lethalBotAI != null 
+                        && (lethalBotAI.OwnerClientId == clientId 
+                            || lethalBotAI.currentOwnershipOnThisClient == playerClientId))
+                    {
+                        // Change the ownership
+                        lethalBotAI.ChangeOwnershipOfEnemy(NetworkManager.ServerClientId);
+
+                        // To prevent desyncs, make the bot leave the terminal
+                        if (lethalBotAI.NpcController.Npc.currentTriggerInAnimationWith == terminalInteractTrigger)
+                        {
+                            lethalBotAI.LeaveTerminal(syncTerminalInUse: true, forceEndUse: true);
+                        }
+                    }
+                }
+            }
         }
 
         /// <summary>

--- a/Patches/GameEnginePatches/StartOfRoundPatch.cs
+++ b/Patches/GameEnginePatches/StartOfRoundPatch.cs
@@ -722,47 +722,6 @@ namespace LethalBots.Patches.GameEnginePatches
             }
         }
 
-        /// <summary>
-        /// If a player leaves the game, have the bots swap their ownership back to the host!
-        /// </summary>
-        /// <param name="__instance"></param>
-        /// <param name="clientId"></param>
-        [HarmonyPatch("OnPlayerDC")]
-        [HarmonyPrefix]
-        static void OnPlayerDC_Postfix(StartOfRound __instance, ulong clientId)
-        {
-            // Don't do this if the host disconnects
-            if (clientId == NetworkManager.ServerClientId)
-            {
-                return;
-            }
-
-            // Only run this for the server and the player disconnecting
-            if (!__instance.IsServer && clientId != GameNetworkManager.Instance.localPlayerController.actualClientId)
-            {
-                return;
-            }
-
-            // Change the bot's ownership to the host
-            foreach (LethalBotAI lethalBotAI in LethalBotManager.Instance.GetLethalBotAIs())
-            {
-                // Check to see if the bot is owned by the disconnecting client
-                if (lethalBotAI != null && lethalBotAI.OwnerClientId == clientId)
-                {
-                    // Change the ownership
-                    if (__instance.IsServer)
-                    {
-                        lethalBotAI.ChangeOwnershipOfEnemy(NetworkManager.ServerClientId);
-                    }
-                    // To prevent desyncs, make the bot leave the terminal
-                    else if (lethalBotAI.NpcController.Npc.inTerminalMenu)
-                    {
-                        lethalBotAI.LeaveTerminal();
-                    }
-                }
-            }
-        }
-
         [HarmonyPatch("LateUpdate")]
         [HarmonyPostfix]
         static void LateUpdate_PostFix(StartOfRound __instance)

--- a/Patches/GameEnginePatches/StartOfRoundPatch.cs
+++ b/Patches/GameEnginePatches/StartOfRoundPatch.cs
@@ -722,6 +722,47 @@ namespace LethalBots.Patches.GameEnginePatches
             }
         }
 
+        /// <summary>
+        /// If a player leaves the game, have the bots swap their ownership back to the host!
+        /// </summary>
+        /// <param name="__instance"></param>
+        /// <param name="clientId"></param>
+        [HarmonyPatch("OnPlayerDC")]
+        [HarmonyPrefix]
+        static void OnPlayerDC_Postfix(StartOfRound __instance, ulong clientId)
+        {
+            // Don't do this if the host disconnects
+            if (clientId == NetworkManager.ServerClientId)
+            {
+                return;
+            }
+
+            // Only run this for the server and the player disconnecting
+            if (!__instance.IsServer && clientId != GameNetworkManager.Instance.localPlayerController.actualClientId)
+            {
+                return;
+            }
+
+            // Change the bot's ownership to the host
+            foreach (LethalBotAI lethalBotAI in LethalBotManager.Instance.GetLethalBotAIs())
+            {
+                // Check to see if the bot is owned by the disconnecting client
+                if (lethalBotAI != null && lethalBotAI.OwnerClientId == clientId)
+                {
+                    // Change the ownership
+                    if (__instance.IsServer)
+                    {
+                        lethalBotAI.ChangeOwnershipOfEnemy(NetworkManager.ServerClientId);
+                    }
+                    // To prevent desyncs, make the bot leave the terminal
+                    else if (lethalBotAI.NpcController.Npc.inTerminalMenu)
+                    {
+                        lethalBotAI.LeaveTerminal();
+                    }
+                }
+            }
+        }
+
         [HarmonyPatch("LateUpdate")]
         [HarmonyPostfix]
         static void LateUpdate_PostFix(StartOfRound __instance)

--- a/Patches/NpcPatches/PlayerControllerBPatch.cs
+++ b/Patches/NpcPatches/PlayerControllerBPatch.cs
@@ -932,6 +932,30 @@ namespace LethalBots.Patches.NpcPatches
         //    });
         //}
 
+        [HarmonyPatch("SendNewPlayerValuesClientRpc")]
+        [HarmonyPostfix]
+        static void SendNewPlayerValuesClientRpc_PostFix(PlayerControllerB __instance)
+        {
+            if (LethalBotManager.Instance == null)
+            {
+                return; // No manager means no bots
+            }
+
+            // Update lethal bots names back to the way they were
+            foreach (LethalBotAI lethalBotAI in LethalBotManager.Instance.GetLethalBotAIs())
+            {
+                PlayerControllerB? lethalBotController = lethalBotAI.NpcController?.Npc;
+                if (lethalBotController != null && lethalBotAI.LethalBotIdentity != null)
+                {
+                    string botName = lethalBotAI.LethalBotIdentity.Name;
+                    lethalBotController.playerUsername = botName;
+                    lethalBotController.usernameBillboardText.text = botName;
+                    lethalBotController.quickMenuManager.AddUserToPlayerList(0ul, botName, (int)lethalBotController.playerClientId);
+                    StartOfRound.Instance.mapScreen.radarTargets[(int)lethalBotController.playerClientId].name = botName;
+                }
+            }
+        }
+
         [HarmonyPatch("KillPlayer")]
         [HarmonyPostfix]
         static void KillPlayer_PostFix(PlayerControllerB __instance)

--- a/Thunderstore/CHANGELOG.md
+++ b/Thunderstore/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 6.1.1 2026-4-24
+Hello, I'm just making some bug fixes for issues that were reported.
+
+Change Log:
+- Updated suit code to also check if the suit Interactable Trigger is spawned just in case it doesn't properly set the appropriate flags
+- Fixed a rare bug where a player who joins late could tell the terminal bot to follow them which would break the terminal for other players. Kicking the bot was on the only way to fix this before this patch.
+- Fixed bot names being changed to Unnamed if a player joins the lobby while there are active bots
+- Added another safeguard for the bots held item not being set for player who join in late.
+- Fixed player names not being reset when a bot disconnects in a LAN lobby
+- Fixed bots controlled by disconnecting players not changing their ownership back to the host
+- Fixed bots in the BrainDeadState not changing to another AI state if the ship was in orbit and they were revived
+- Adjusted LethalBotAI.LeaveTerminal to allow the server to force the bot off of the terminal
+- Singleton_OnClientDisconnectCallback now properly updates the real player count after a human player disconnects
+- Made some minor optimizations
+
 ## 6.1.0 2026-4-23
 There was reported a bug with the bots causing infinite loading loops when trying to change moons if you had DawnLib installed. This has been fixed along with a few other bugs with some other mods as well. I also added #36 since it was no longer blocked by a pending update to Usual Scrap.
 


### PR DESCRIPTION
Hello, I'm just making some bug fixes for issues that were reported.

Change Log:
- Updated suit code to also check if the suit Interactable Trigger is spawned just in case it doesn't properly set the appropriate flags
- Fixed a rare bug where a player who joins late could tell the terminal bot to follow them which would break the terminal for other players. Kicking the bot was on the only way to fix this before this patch.
- Fixed bot names being changed to Unnamed if a player joins the lobby while there are active bots
- Added another safeguard for the bots held item not being set for player who join in late.
- Fixed player names not being reset when a bot disconnects in a LAN lobby
- Fixed bots controlled by disconnecting players not changing their ownership back to the host
- Fixed bots in the BrainDeadState not changing to another AI state if the ship was in orbit and they were revived
- Adjusted LethalBotAI.LeaveTerminal to allow the server to force the bot off of the terminal
- Singleton_OnClientDisconnectCallback now properly updates the real player count after a human player disconnects
- Made some minor optimizations
