### PR TITLE
6.1.2 Spawning Bug Fix

### DIFF
--- a/LethalBot.csproj
+++ b/LethalBot.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>LethalBots</AssemblyName>
     <Product>LethalBots</Product>
     <!-- Change to whatever version you're currently on. This will be used by tcli when building our Thunderstore package. -->
-    <Version>6.1.1</Version>
+    <Version>6.1.2</Version>
   </PropertyGroup>
 
   <!-- Project Properties -->

--- a/Managers/LethalBotManager.cs
+++ b/Managers/LethalBotManager.cs
@@ -1385,6 +1385,7 @@ namespace LethalBots.Managers
             //lethalBotAI.transform.parent = objectParent.transform;
             //lethalBotAI.NetworkObject.AutoObjectParentSync = true;
             lethalBotAI.enabled = true;
+            objectParent.SetActive(true); // Think that some optimization mods disable the player controller, we need to force renable them here
             if (clientJoining && lethalBotController.currentlyHeldObject != null)
             {
                 lethalBotAI.HeldItem = lethalBotController.currentlyHeldObject;

--- a/Thunderstore/CHANGELOG.md
+++ b/Thunderstore/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 6.1.2 2026-4-24
+Hello, 6.1.1 had an issue where certian mods could cause the bots player controller to be disabled.
+I have now restored the part of the code that enables the player controllers when a bot spawns which should fix the issue.
+
 ## 6.1.1 2026-4-24
 Hello, I'm just making some bug fixes for issues that were reported.
 


### PR DESCRIPTION
Restored the enabling of the bot player controller when the bot spawns

- This should fix the issue where the bot spawns, but is invisible if certain mods are installed. Fixes #90