### PR TITLE
6.1.3 HealPlayerState Type Error Fix

### DIFF
--- a/AI/AIStates/HealPlayerState.cs
+++ b/AI/AIStates/HealPlayerState.cs
@@ -76,7 +76,7 @@ namespace LethalBots.AI.AIStates
             {
                 sprayPaintItem.UseItemOnClient(false);
             }
-            else if (FindUsualScrapMedkit(heldItem))
+            else if (Plugin.IsModUsualScrapLoaded && FindUsualScrapMedkit(heldItem))
             {
                 heldItem.UseItemOnClient(false);
             }
@@ -185,11 +185,11 @@ namespace LethalBots.AI.AIStates
             {
                 return HealMethod.WeedKiller;
             }
-            else if (CanHealPlayerWithUsualScrapMedkit(ai, this.healTarget))
+            else if (Plugin.IsModUsualScrapLoaded && CanHealPlayerWithUsualScrapMedkit(ai, this.healTarget))
             {
                 return HealMethod.ModUsualScrapMedkit;
             }
-            else if (CanHealPlayerWithUsualScrapBandage(ai, this.healTarget))
+            else if (Plugin.IsModUsualScrapLoaded && CanHealPlayerWithUsualScrapBandage(ai, this.healTarget))
             {
                 return HealMethod.ModUsualScrapBandage;
             }
@@ -361,11 +361,11 @@ namespace LethalBots.AI.AIStates
             {
                 return true;
             }
-            else if (CanHealPlayerWithUsualScrapMedkit(lethalBotAI, healTarget))
+            else if (Plugin.IsModUsualScrapLoaded && CanHealPlayerWithUsualScrapMedkit(lethalBotAI, healTarget))
             {
                 return true;
             }
-            else if (CanHealPlayerWithUsualScrapBandage(lethalBotAI, healTarget))
+            else if (Plugin.IsModUsualScrapLoaded && CanHealPlayerWithUsualScrapBandage(lethalBotAI, healTarget))
             {
                 return true;
             }

--- a/LethalBot.csproj
+++ b/LethalBot.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>LethalBots</AssemblyName>
     <Product>LethalBots</Product>
     <!-- Change to whatever version you're currently on. This will be used by tcli when building our Thunderstore package. -->
-    <Version>6.1.2</Version>
+    <Version>6.1.3</Version>
   </PropertyGroup>
 
   <!-- Project Properties -->

--- a/Thunderstore/CHANGELOG.md
+++ b/Thunderstore/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 6.1.3 2026-4-24
+Sigh, I only discovered this bug because I died because of it.........Bots were unable to cure players if the mod Usual Scrap was not installed. 
+This was caused by a logic error that caused my mod to not check if it was installed or not in the HealPlayerState.
+
+Bots are now able to cure players again without spaming the console with TypeLoadExceptions
+
 ## 6.1.2 2026-4-24
 Hello, 6.1.1 had an issue where certian mods could cause the bots player controller to be disabled.
 I have now restored the part of the code that enables the player controllers when a bot spawns which should fix the issue.


### PR DESCRIPTION
Sigh, I only discovered this bug because I died because of it.........Bots were unable to cure players if the mod Usual Scrap was not installed. 
This was caused by a logic error that caused my mod to not check if it was installed or not in the HealPlayerState.

Bots are now able to cure players again without spaming the console with TypeLoadExceptions