### PR TITLE
7.0.1 Bug Fixes

### DIFF
--- a/AI/AIState.cs
+++ b/AI/AIState.cs
@@ -1333,7 +1333,7 @@ namespace LethalBots.AI
                         }
 
                         // Node is either covered in quicksand or is underwater! Pick another one!
-                        if (IsPositionCoveredInQuickSand(nodePos))
+                        if (IsPositionCoveredInQuickSand(nodePos, checkClosestNode: false))
                         {
                             continue;
                         }

--- a/AI/AIStates/PanikState.cs
+++ b/AI/AIStates/PanikState.cs
@@ -579,7 +579,6 @@ namespace LethalBots.AI.AIStates
 
                 GrabbableObject? foundItem = gameObject.GetComponent<GrabbableObject>();
                 if (foundItem != null
-                    && foundItem.isInShipRoom
                     && ai.HasAmmoForWeapon(foundItem))
                 {
                     // Ignore the just dropped item timer, we are already in DANGER!

--- a/AI/LethalBotAI.cs
+++ b/AI/LethalBotAI.cs
@@ -556,6 +556,8 @@ namespace LethalBots.AI
                     NpcController.SetTurnBodyTowardsDirection(ourTrigger.playerPositionNode.rotation.eulerAngles); // NEEDTOVALIDATE: Is this correct?
                 }
                 SetAgent(enabled: false);
+                this.transform.position = NpcController.Npc.transform.position;
+                this.serverPosition = NpcController.Npc.transform.position;
                 return;
             }
 
@@ -6535,30 +6537,6 @@ namespace LethalBots.AI
 
         #endregion
 
-        #region SyncDeadBodyPosition RPC
-
-        /// <summary>
-        /// Server side, call the clients to update the dead body of the lethalBot
-        /// </summary>
-        /// <param name="newBodyPosition">New dead body position</param>
-        [ServerRpc(RequireOwnership = false)]
-        public void SyncDeadBodyPositionServerRpc(Vector3 newBodyPosition)
-        {
-            SyncDeadBodyPositionClientRpc(newBodyPosition);
-        }
-
-        /// <summary>
-        /// Client side, update the dead body of the lethalBot
-        /// </summary>
-        /// <param name="newBodyPosition">New dead body position</param>
-        [ClientRpc]
-        private void SyncDeadBodyPositionClientRpc(Vector3 newBodyPosition)
-        {
-            PlayerControllerBPatch.SyncBodyPositionClientRpc_ReversePatch(NpcController.Npc, newBodyPosition);
-        }
-
-        #endregion
-
         #region SyncFaceUnderwater
 
         [ServerRpc(RequireOwnership = false)]
@@ -9825,7 +9803,7 @@ namespace LethalBots.AI
             isTouchingGround = Physics.Raycast(new Ray(lethalBotPosition + Vector3.up, Vector3.down),
                                                out groundHit,
                                                2.5f,
-                                               StartOfRound.Instance.collidersAndRoomMaskAndDefault, QueryTriggerInteraction.Ignore);
+                                               StartOfRound.Instance.walkableSurfacesMask, QueryTriggerInteraction.Ignore);
         }
     }
 }

--- a/AI/NpcController.cs
+++ b/AI/NpcController.cs
@@ -1478,7 +1478,7 @@ namespace LethalBots.AI
                 }
                 if ((localPlayerPos - Npc.transform.position).sqrMagnitude < 20f * 20f)
                 {
-                    PlayFootstepSound();
+                    Npc.PlayFootstepSound();
                 }
             }
         }
@@ -1518,28 +1518,6 @@ namespace LethalBots.AI
                 Plugin.LogDebug($"{Npc.playerUsername} Play audible noise for {enemyAI.name}");
                 enemyAINoiseListener.Value.DetectNoise(noisePosition, noiseLoudness, timesPlayedInSameSpot, noiseID);
             }
-        }
-
-        private void PlayFootstepSound()
-        {
-            AudioClip[] currentFootstepAudioClips = StartOfRound.Instance.footstepSurfaces[Npc.currentFootstepSurfaceIndex].clips;
-            int currentFootstepAudioClip = Random.Range(0, currentFootstepAudioClips.Length);
-            if (currentFootstepAudioClip == this.previousFootstepClip)
-            {
-                currentFootstepAudioClip = (currentFootstepAudioClip + 1) % currentFootstepAudioClips.Length;
-            }
-            Npc.movementAudio.pitch = Random.Range(0.93f, 1.07f);
-
-            bool flag = LethalBotAIController.IsOwner ? Npc.isSprinting : Npc.playerBodyAnimator.GetCurrentAnimatorStateInfo(0).IsTag(Const.PLAYER_ANIMATION_BOOL_SPRINTING);
-            float volumeScale = 0.9f;
-            if (!flag)
-            {
-                volumeScale = 0.6f;
-            }
-
-            Npc.movementAudio.PlayOneShot(currentFootstepAudioClips[currentFootstepAudioClip], volumeScale);
-            this.previousFootstepClip = currentFootstepAudioClip;
-            WalkieTalkie.TransmitOneShotAudio(Npc.movementAudio, StartOfRound.Instance.footstepSurfaces[Npc.currentFootstepSurfaceIndex].clips[currentFootstepAudioClip], volumeScale);
         }
 
         #endregion

--- a/LethalBot.csproj
+++ b/LethalBot.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>LethalBots</AssemblyName>
     <Product>LethalBots</Product>
     <!-- Change to whatever version you're currently on. This will be used by tcli when building our Thunderstore package. -->
-    <Version>7.0.0</Version>
+    <Version>7.0.1</Version>
   </PropertyGroup>
 
   <!-- Project Properties -->

--- a/Managers/LethalBotManager.cs
+++ b/Managers/LethalBotManager.cs
@@ -123,8 +123,6 @@ namespace LethalBots.Managers
 
         #endregion
 
-        private static PlayerControllerB? _hostPlayerScript;
-
         /// <summary>
         /// Public property used to return the host player object!
         /// </summary>
@@ -132,18 +130,18 @@ namespace LethalBots.Managers
         { 
             get
             {
-                if (_hostPlayerScript == null || !_hostPlayerScript.isHostPlayerObject)
+                if (field == null || !field.isHostPlayerObject)
                 {
                     foreach (PlayerControllerB player in StartOfRound.Instance.allPlayerScripts)
                     {
                         if (player != null && player.isHostPlayerObject)
                         {
-                            _hostPlayerScript = player;
+                            field = player;
                             break;
                         }
                     }
                 }
-                return _hostPlayerScript;
+                return field;
             }
         }
 

--- a/Patches/GameEnginePatches/RoundManagerPatch.cs
+++ b/Patches/GameEnginePatches/RoundManagerPatch.cs
@@ -127,7 +127,7 @@ namespace LethalBots.Patches.GameEnginePatches
                         navMeshModifierGameObject.transform.SetParent(boxCollider.transform, worldPositionStays: true);
                         navMeshModifierGameObject.transform.localPosition = Vector3.zero;
                         navMeshModifierGameObject.transform.localRotation = Quaternion.identity;
-                        navMeshModifierGameObject.layer = LayerMask.GetMask("NavigationSurface");
+                        navMeshModifierGameObject.layer = LayerMask.NameToLayer("NavigationSurface");
 
                         // Add the NavMeshVolume
                         NavMeshModifierVolume navMeshModifier = navMeshModifierGameObject.AddComponent<NavMeshModifierVolume>();

--- a/Patches/GameEnginePatches/RoundManagerPatch.cs
+++ b/Patches/GameEnginePatches/RoundManagerPatch.cs
@@ -172,6 +172,22 @@ namespace LethalBots.Patches.GameEnginePatches
         }
 
         /// <summary>
+        /// Make sure to include our custom quicksand mask to enemies!
+        /// </summary>
+        /// <param name="__instance"></param>
+        /// <param name="supplyExistingMask"></param>
+        /// <param name="__result"></param>
+        [HarmonyPatch("GetLayermaskForEnemySizeLimit")]
+        [HarmonyPostfix]
+        static void GetLayermaskForEnemySizeLimit_Postfix(RoundManager __instance, bool supplyExistingMask, ref int __result)
+        {
+            if (supplyExistingMask)
+            {
+                __result |= 1 << Const.LETHAL_BOT_QUICKSAND_NAVAREA;
+            }
+        }
+
+        /// <summary>
         /// Patch for debug spawn bush spawn point
         /// </summary>
         [HarmonyPatch("LoadNewLevel")]

--- a/Patches/MapHazardsPatches/LandminePatch.cs
+++ b/Patches/MapHazardsPatches/LandminePatch.cs
@@ -3,8 +3,13 @@ using HarmonyLib;
 using LethalBots.AI;
 using LethalBots.Enums;
 using LethalBots.Managers;
+using LethalBots.Utils;
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using Unity.Netcode;
 using UnityEngine;
 
 namespace LethalBots.Patches.MapHazardsPatches
@@ -220,6 +225,67 @@ namespace LethalBots.Patches.MapHazardsPatches
 
                 lethalBotsAlreadyExploded.Add(lethalBotController.playerClientId);
             }
+        }
+
+        /// <summary>
+        /// This fixes a rare bug where bots could die in place of the local player..........
+        /// </summary>
+        /// <param name="instructions"></param>
+        /// <param name="generator"></param>
+        /// <returns></returns>
+        [HarmonyPatch("SpawnExplosion")]
+        [HarmonyTranspiler]
+        static IEnumerable<CodeInstruction> SpawnExplosion_Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
+        {
+            var startIndex = -1;
+            var codes = new List<CodeInstruction>(instructions);
+
+            /*Plugin.LogDebug("Before patching IL instructions:");
+            foreach (var instruction in codes)
+            {
+                Plugin.LogDebug(instruction.ToString());
+            }*/
+
+            // Target property: IsOwner
+            MethodInfo isOwnerGetter = AccessTools.PropertyGetter(typeof(NetworkBehaviour), "IsOwner");
+
+            // Lets us know that the patching has begun!
+            Plugin.LogDebug("Beginning to patch Landmine.SpawnExplosion!");
+
+            // ---------- Step 1: Replace 'playerControllerB.IsOwner' ----------
+            for (var i = 0; i < codes.Count; i++)
+            {
+                // Look for occurrences of "IsOwner"
+                if (codes[i].Calls(isOwnerGetter))
+                {
+                    // Replace with IsPlayerLocal
+                    startIndex = i;
+                    break;
+                }
+            }
+
+            if (startIndex != -1)
+            {
+                // Replace the old instruction to call the replacement method.
+                codes[startIndex].opcode = OpCodes.Call;
+                codes[startIndex].operand = PatchesUtil.IsPlayerLocalMethod; // Call our replacement method
+                startIndex = -1;
+            }
+            else
+            {
+                Plugin.LogError($"LethalBot.Patches.MapHazardsPatches.Landmine.SpawnExplosion_Transpiler could not find the IsOwner call!");
+            }
+
+            // Let the user know that we finished
+            Plugin.LogDebug("Finished patching Landmine.SpawnExplosion!");
+
+            /*Plugin.LogDebug("After patching IL instructions:");
+            foreach (var instruction in codes)
+            {
+                Plugin.LogDebug(instruction.ToString());
+            }*/
+
+            return codes.AsEnumerable();
         }
     }
 }

--- a/Patches/NpcPatches/EnemyAIPatch.cs
+++ b/Patches/NpcPatches/EnemyAIPatch.cs
@@ -88,7 +88,29 @@ namespace LethalBots.Patches.NpcPatches
         static void Start_Postfix(EnemyAI __instance)
         {
             if (__instance.IsServer && __instance is not LethalBotAI && !RoundManager.Instance.SpawnedEnemies.Contains(__instance))
+            {
                 RoundManager.Instance.SpawnedEnemies.Add(__instance);
+            }
+
+            // Make sure to include our custom quicksand mask to enemies!
+            __instance.agentMask |= 1 << Const.LETHAL_BOT_QUICKSAND_NAVAREA;
+            __instance.agent.areaMask |= 1 << Const.LETHAL_BOT_QUICKSAND_NAVAREA;
+        }
+
+        /// <summary>
+        /// Make sure to include our custom quicksand mask to enemies!
+        /// </summary>
+        /// <param name="__instance"></param>
+        /// <param name="supplyExistingMask"></param>
+        /// <param name="__result"></param>
+        [HarmonyPatch("GetLayermaskForEnemySizeLimit")]
+        [HarmonyPostfix]
+        static void GetLayermaskForEnemySizeLimit_Postfix(EnemyAI __instance, bool supplyExistingMask, ref int __result)
+        {
+            if (supplyExistingMask)
+            {
+                __result |= 1 << Const.LETHAL_BOT_QUICKSAND_NAVAREA;
+            }
         }
 
         #region Transpilers

--- a/Patches/NpcPatches/EnemyAIPatch.cs
+++ b/Patches/NpcPatches/EnemyAIPatch.cs
@@ -97,22 +97,6 @@ namespace LethalBots.Patches.NpcPatches
             __instance.agent.areaMask |= 1 << Const.LETHAL_BOT_QUICKSAND_NAVAREA;
         }
 
-        /// <summary>
-        /// Make sure to include our custom quicksand mask to enemies!
-        /// </summary>
-        /// <param name="__instance"></param>
-        /// <param name="supplyExistingMask"></param>
-        /// <param name="__result"></param>
-        [HarmonyPatch("GetLayermaskForEnemySizeLimit")]
-        [HarmonyPostfix]
-        static void GetLayermaskForEnemySizeLimit_Postfix(EnemyAI __instance, bool supplyExistingMask, ref int __result)
-        {
-            if (supplyExistingMask)
-            {
-                __result |= 1 << Const.LETHAL_BOT_QUICKSAND_NAVAREA;
-            }
-        }
-
         #region Transpilers
 
         /// <summary>

--- a/Patches/NpcPatches/PlayerControllerBPatch.cs
+++ b/Patches/NpcPatches/PlayerControllerBPatch.cs
@@ -158,7 +158,9 @@ namespace LethalBots.Patches.NpcPatches
         /// <returns></returns>
         [HarmonyPatch("DamagePlayer")]
         [HarmonyPrefix]
+        [HarmonyPriority(Priority.Last)]
         static bool DamagePlayer_PreFix(PlayerControllerB __instance,
+                                        bool __runOriginal,
                                         int damageNumber,
                                         bool hasDamageSFX = true,
                                         bool callRPC = true,
@@ -167,6 +169,12 @@ namespace LethalBots.Patches.NpcPatches
                                         bool fallDamage = false,
                                         Vector3 force = default(Vector3))
         {
+            // If other mods block this call, we don't do anything!
+            if (!__runOriginal)
+            {
+                return true; // Let the base game not run........
+            }
+
             LethalBotAI? lethalBotAI = LethalBotManager.Instance.GetLethalBotAI(__instance);
             if (lethalBotAI != null)
             {
@@ -174,8 +182,8 @@ namespace LethalBots.Patches.NpcPatches
                 lethalBotAI.DamageLethalBot(damageNumber, hasDamageSFX, callRPC, causeOfDeath, deathAnimation, fallDamage, force);
                 
                 // Still do the vanilla damage player, for other mods prefixes (ex: peepers)
-                // The damage will be ignored because the lethalBot playerController is not owned because not spawned
-                return false;
+                // The damage will be ignored because of the transpiler patch I made to skip all damage logic for LethalBots!
+                return true;
             }
 
             if (DebugConst.NO_DAMAGE)
@@ -826,6 +834,44 @@ namespace LethalBots.Patches.NpcPatches
             {
                 Plugin.LogDebug($"Patched out timeAtMakingLastPersonalMovement for bots in Crouch {timesPatched} times!");
             }
+
+            return codes.AsEnumerable();
+        }
+
+        /// <summary>
+        /// So you might ask, why do we need to transpile the damage player method when we have a prefix for it?
+        /// You see unlike the KillPlayer function, I can't just skip it by changing the isPlayerDead flag to true.
+        /// My solution, I patch this function to check if the player is a bot.
+        /// If so, I force the function to return early and let my prefix handle the damage logic instead.
+        /// This allows Postfixes from other mods to still run and not break compatibility, while also allowing the lethalBot to take damage
+        /// </summary>
+        /// <param name="instructions"></param>
+        /// <param name="generator"></param>
+        /// <returns></returns>
+        [HarmonyPatch("DamagePlayer")]
+        [HarmonyTranspiler]
+        public static IEnumerable<CodeInstruction> DamagePlayer_Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
+        {
+            // The start index is 0 since we want to insert our check at the very start of the method to skip all the
+            // damage logic for bots and let our prefix handle it instead!
+            const int startIndex = 0;
+            var codes = new List<CodeInstruction>(instructions);
+
+            // Create our label's destination....
+            Label skipSnapshot = generator.DefineLabel();
+            codes[startIndex].labels.Add(skipSnapshot);
+
+            // Insert new method call to return early if this is a bot controller
+            List<CodeInstruction> codesToAdd = new List<CodeInstruction>
+            {
+                new CodeInstruction(OpCodes.Ldarg_0),
+                new CodeInstruction(OpCodes.Call, PatchesUtil.IsPlayerLethalBotMethod),
+                new CodeInstruction(OpCodes.Brfalse, skipSnapshot),
+                new CodeInstruction(OpCodes.Ret)
+            };
+
+            // Insert the new instruction to call the replacement method.
+            codes.InsertRange(startIndex, codesToAdd);
 
             return codes.AsEnumerable();
         }

--- a/Patches/NpcPatches/PlayerControllerBPatch.cs
+++ b/Patches/NpcPatches/PlayerControllerBPatch.cs
@@ -309,7 +309,7 @@ namespace LethalBots.Patches.NpcPatches
             if (__instance.deadBody != null)
             {
                 // Replace body position or else disappear with shotgun or knife (don't know why)
-                __instance.deadBody.transform.position = __instance.transform.position + Vector3.up + positionOffset;
+                //__instance.deadBody.transform.position = __instance.transform.position + Vector3.up + positionOffset;
                 lethalBotAI.LethalBotIdentity.DeadBody = __instance.deadBody;
 
                 // Lets make sure the bots don't attempt to grab dead bodies as soon as a player is killed!
@@ -329,7 +329,11 @@ namespace LethalBots.Patches.NpcPatches
             lethalBotAI.LethalBotIdentity.Hp = 0;
             lethalBotAI.SetAgent(enabled: false);
             //this.LethalBotIdentity.Voice.StopAudioFadeOut();
-            lethalBotAI.State = new BrainDeadState(lethalBotAI);
+            if (lethalBotAI.State == null || lethalBotAI.State.GetAIState() != EnumAIStates.BrainDead)
+            {
+                // If the bot was not in the BrainDead state, we set it to it so it doesn't do anything after this!
+                lethalBotAI.State = new BrainDeadState(lethalBotAI);
+            }
         }
 
         /// <summary>
@@ -463,26 +467,6 @@ namespace LethalBots.Patches.NpcPatches
                 __instance.currentTriggerInAnimationWith.StopSpecialAnimation();
             }
             return false;
-        }
-
-        /// <summary>
-        /// Patch to call the right the right method for sync dead body if the lethalBot is calling it
-        /// </summary>
-        /// <returns></returns>
-        [HarmonyPatch("SyncBodyPositionClientRpc")]
-        [HarmonyPrefix]
-        static bool SyncBodyPositionClientRpc_PreFix(PlayerControllerB __instance, Vector3 newBodyPosition)
-        {
-            // send to server if lethalBot from controller
-            LethalBotAI? lethalBotAI = LethalBotManager.Instance.GetLethalBotAI(__instance);
-            if (lethalBotAI != null)
-            {
-                Plugin.LogDebug($"NetworkManager {__instance.NetworkManager}, newBodyPosition {newBodyPosition}, this.deadBody {__instance.deadBody}");
-                lethalBotAI.SyncDeadBodyPositionServerRpc(newBodyPosition);
-                return false;
-            }
-
-            return true;
         }
 
         ///// <summary>
@@ -772,50 +756,6 @@ namespace LethalBots.Patches.NpcPatches
         [HarmonyReversePatch(type: HarmonyReversePatchType.Snapshot)]
         [HarmonyPriority(Priority.Last)]
         public static void IsInSpecialAnimationClientRpc_ReversePatch(object instance, bool specialAnimation, float timed, bool climbingLadder) => throw new NotImplementedException("Stub LethalBot.Patches.NpcPatches.PlayerControllerBPatch.IsInSpecialAnimationClientRpc_ReversePatch");
-
-        /// <summary>
-        /// Reverse patch to be able to call <c>SyncBodyPositionClientRpc</c>
-        /// </summary>
-        /// <remarks>
-        /// Bypassing all rpc condition, because the lethalBot is not owner of his body, no one is, the body <c>PlayerControllerB</c> of lethalBot is not spawned.<br/>
-        /// </remarks>
-        [HarmonyPatch("SyncBodyPositionClientRpc")]
-        [HarmonyReversePatch(type: HarmonyReversePatchType.Snapshot)]
-        [HarmonyPriority(Priority.Last)]
-        public static void SyncBodyPositionClientRpc_ReversePatch(object instance, Vector3 newBodyPosition)
-        {
-            /*IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
-            {
-                var startIndex = -1;
-                List<CodeInstruction> codes = new List<CodeInstruction>(instructions);
-
-                // ----------------------------------------------------------------------
-                for (var i = 0; i < codes.Count - 6; i++)
-                {
-                    if (codes[i].ToString().StartsWith("nop NULL")// 53
-                        && codes[i + 9].ToString().StartsWith("call static float UnityEngine.Vector3::Distance(UnityEngine.Vector3 a, UnityEngine.Vector3 b)"))// 62
-                    {
-                        startIndex = i;
-                        break;
-                    }
-                }
-                if (startIndex > -1)
-                {
-                    codes.Insert(0, new CodeInstruction(OpCodes.Br, codes[startIndex].labels[0]));
-                    startIndex = -1;
-                }
-                else
-                {
-                    Plugin.LogError($"LethalBot.Patches.NpcPatches.PlayerControllerBPatch.SyncBodyPositionClientRpc_ReversePatch could not bypass rpc stuff");
-                }
-
-                return codes.AsEnumerable();
-            }
-
-#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
-            _ = Transpiler(null);
-#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.*/
-        }
 
         [HarmonyPatch("SetSpecialGrabAnimationBool")]
         [HarmonyReversePatch(type: HarmonyReversePatchType.Snapshot)]

--- a/Thunderstore/CHANGELOG.md
+++ b/Thunderstore/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 7.0.1 2026-4-30
+Hello again, I just have some minor bug fixes for some issues that were found after the 7.0.0 Update.
+
+Change Log:
+- Fixed bots in the Panik state not grabbing nearby weapons if said weapon wasn't on the ship
+- Fixed Safe Path considering underwater nodes as a good fallback spot
+- Fixed a potential desync between the bot's player controller and its NavMeshAgent
+- Changed bots to use PlayerControllerB.PlayFootstepSound which fixed the scrap jiggle audio to not playing
+- Made a minor optimization to LethalBotManager.HostPlayerScript
+- Fixed some issues with the Quicksand NavMeshAttribute causing some enemies to fail to path over quicksand.
+- Fixed a bug with late joining players where a bot could be selected to die in SpawnExplosion causing the local player to not take any kind of damage from said explosion.
+- Forced all EnemyAI objects to include my quicksand NavMeshAttribute in their areaMask
+- Fixed some logic errors in KillPlayerClientRpc_Postfix
+- Changed how player damage is handled for bots
+  - Lethal Bots no longer blocks the orignal damage player function from running for bots.
+  - A transpiler was used to make the orignal DamagePlayer function return early if its called on a bot
+  - This allows mod added Postfixes for DamagePlayer to properly run for bots
+
 ## 7.0.0 2026-4-28
 It time for another update. This more focused around reworking some of the bot's AI itself. Now then lets get right onto it!
 


### PR DESCRIPTION
Hello again, I just have some minor bug fixes for some issues that were found after the 7.0.0 Update.

Change Log:
- Fixed bots in the Panik state not grabbing nearby weapons if said weapon wasn't on the ship
- Fixed Safe Path considering underwater nodes as a good fallback spot
- Fixed a potential desync between the bot's player controller and its NavMeshAgent
- Changed bots to use PlayerControllerB.PlayFootstepSound which fixed the scrap jiggle audio to not playing
- Made a minor optimization to LethalBotManager.HostPlayerScript
- Fixed some issues with the Quicksand NavMeshAttribute causing some enemies to fail to path over quicksand.
- Fixed a bug with late joining players where a bot could be selected to die in SpawnExplosion causing the local player to not take any kind of damage from said explosion.
- Forced all EnemyAI objects to include my quicksand NavMeshAttribute in their areaMask
- Fixed some logic errors in KillPlayerClientRpc_Postfix
- Changed how player damage is handled for bots
 - Lethal Bots no longer blocks the orignal damage player function from running for bots.
 - A transpiler was used to make the orignal DamagePlayer function return early if its called on a bot
 - This allows mod added Postfixes for DamagePlayer to properly run for bots