### PR TITLE
7.0.3 Multiplayer Hash Fix

### DIFF
--- a/LethalBot.csproj
+++ b/LethalBot.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>LethalBots</AssemblyName>
     <Product>LethalBots</Product>
     <!-- Change to whatever version you're currently on. This will be used by tcli when building our Thunderstore package. -->
-    <Version>7.0.2</Version>
+    <Version>7.0.3</Version>
   </PropertyGroup>
 
   <!-- Project Properties -->

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -170,7 +170,10 @@ namespace LethalBots
             }
 
             // randomize GlobalObjectIdHash
-            byte[] value = MD5.Create().ComputeHash(Encoding.UTF8.GetBytes(Assembly.GetCallingAssembly().GetName().Name + gameObject.name + bundleName));
+            //Logger.LogInfo($"Calling Assembly Name: {typeof(Plugin).Assembly.GetName().Name}");
+            //Logger.LogInfo($"Prefab Name: {gameObject.name}");
+            //Logger.LogInfo($"Bundle Name: {bundleName}");
+            byte[] value = MD5.Create().ComputeHash(Encoding.UTF8.GetBytes(typeof(Plugin).Assembly.GetName().Name + gameObject.name + bundleName));
             uint newGlobalObjectIdHash = BitConverter.ToUInt32(value, 0);
             Type type = typeof(NetworkObject);
             FieldInfo fieldInfo = type.GetField("GlobalObjectIdHash", BindingFlags.NonPublic | BindingFlags.Instance);

--- a/Thunderstore/CHANGELOG.md
+++ b/Thunderstore/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 7.0.3 2026-5-3
 I have no idea how long this has been a bug, but I fixed the Lethal Bot Prefab hash sometimes not being consistent between clients.
+This caused a rare bug where some players would be unable to join their friend's lobby even if they had the same modpack!
 
 ## 7.0.2 2026-5-1
 Just a minor patch to publicize some ship navmesh fields to help modders add support for their custom ship sizes!

--- a/Thunderstore/CHANGELOG.md
+++ b/Thunderstore/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 7.0.3 2026-5-3
+I have no idea how long this has been a bug, but I fixed the Lethal Bot Prefab hash sometimes not being consistent between clients.
+
 ## 7.0.2 2026-5-1
 Just a minor patch to publicize some ship navmesh fields to help modders add support for their custom ship sizes!
 


### PR DESCRIPTION
I have no idea how long this has been a bug, but I fixed the Lethal Bot Prefab hash sometimes not being consistent between clients.
This caused a rare bug where some players would be unable to join their friend's lobby even if they had the same modpack!