### PR TITLE
Bot command variations update + Separated 'Talkativeness' into Talkativeness and Responsiveness

### DIFF
--- a/AI/AIState.cs
+++ b/AI/AIState.cs
@@ -247,33 +247,39 @@ namespace LethalBots.AI
 
             // One of us was asked to be the mission controller!
             // NOTE: playerWhoSentMessage should never be null here, but other modders could call this function directly with a null value!
-            ChatCommandsManager.RegisterGlobalCommand(new ChatCommand(Const.MAN_THE_SHIP_COMMAND, (state, lethalBotAI, playerWhoSentMessage, message, isVoice) =>
+            foreach (string cmd in Const.MAN_THE_SHIP_COMMANDS)
             {
-                if (state.IsBotBeingAddressed(playerWhoSentMessage, out var lethalBotController))
+                ChatCommandsManager.RegisterGlobalCommand(new ChatCommand(cmd, (state, lethalBotAI, playerWhoSentMessage, message, isVoice) =>
                 {
-                    // Yay, we found a vaild bot, make it the mission controller!
-                    lethalBotAI.SendChatMessage("Alright, I'll head to the terminal and watch over the crew!");
-                    LethalBotManager.Instance.MissionControlPlayer = lethalBotController;
-                    lethalBotAI.State = new MissionControlState(state); // Its fine to set the state here directly, if we are not on the ship, the state will handle moving to the ship!
-                }
-                return true;
-            }));
+                    if (state.IsBotBeingAddressed(playerWhoSentMessage, out var lethalBotController))
+                    {
+                        // Yay, we found a vaild bot, make it the mission controller!
+                        lethalBotAI.SendChatMessage("Alright, I'll head to the terminal and watch over the crew!");
+                        LethalBotManager.Instance.MissionControlPlayer = lethalBotController;
+                        lethalBotAI.State = new MissionControlState(state); // Its fine to set the state here directly, if we are not on the ship, the state will handle moving to the ship!
+                    }
+                    return true;
+                }));
+            }
 
             // One of us was asked to transfer loot!
-            ChatCommandsManager.RegisterGlobalCommand(new ChatCommand(Const.TRANSFER_LOOT_COMMAND, (state, lethalBotAI, playerWhoSentMessage, message, isVoice) =>
+            foreach (string cmd in Const.TRANSFER_LOOT_COMMANDS)
             {
-                if (state.IsBotBeingAddressed(playerWhoSentMessage, out var lethalBotController))
+                ChatCommandsManager.RegisterGlobalCommand(new ChatCommand(cmd, (state, lethalBotAI, playerWhoSentMessage, message, isVoice) =>
                 {
-                    // Yay, we found a vaild bot, make it transfer loot!
-                    lethalBotAI.SendChatMessage("I'll start transferring loot to the ship right away!");
-                    if (!LethalBotManager.Instance.LootTransferPlayers.Contains(lethalBotController))
+                    if (state.IsBotBeingAddressed(playerWhoSentMessage, out var lethalBotController))
                     {
-                        LethalBotManager.Instance.AddPlayerToLootTransferListAndSync(lethalBotController);
+                        // Yay, we found a vaild bot, make it transfer loot!
+                        lethalBotAI.SendChatMessage("I'll start transferring loot to the ship right away!");
+                        if (!LethalBotManager.Instance.LootTransferPlayers.Contains(lethalBotController))
+                        {
+                            LethalBotManager.Instance.AddPlayerToLootTransferListAndSync(lethalBotController);
+                        }
+                        lethalBotAI.State = new TransferLootState(state);
                     }
-                    lethalBotAI.State = new TransferLootState(state);
-                }
-                return true;
-            }));
+                    return true;
+                }));
+            }
 
             // A player asked to join our group
             ChatCommandsManager.RegisterGlobalCommand(new ChatCommand(Const.JOIN_GROUP_COMMAND, (state, lethalBotAI, playerWhoSentMessage, message, isVoice) =>

--- a/AI/AIStates/ChillWithPlayerState.cs
+++ b/AI/AIStates/ChillWithPlayerState.cs
@@ -272,40 +272,46 @@ namespace LethalBots.AI.AIStates
         /// <inheritdoc cref="AIState.RegisterChatCommands"/>
         public static new void RegisterChatCommands()
         {
-            ChatCommandsManager.RegisterCommandForState<ChillWithPlayerState>(new ChatCommand(Const.GEAR_UP_COMMAND, (state, lethalBotAI, playerWhoSentMessage, message, isVoice) =>
+            foreach (string cmd in Const.GEAR_UP_COMMANDS)
             {
-                lethalBotAI.State = new GrabLoadoutState(state);
-                return true;
-            }));
-
-            ChatCommandsManager.RegisterCommandForState<ChillWithPlayerState>(new ChatCommand(Const.USE_KEY_COMMAND, (state, lethalBotAI, playerWhoSentMessage, message, isVoice) =>
-            {
-                // Make sure we have a key or lockpicker
-                // Check what door the player is looking at
-                if (!lethalBotAI.HasKeyInInventory() 
-                    || !Physics.Raycast(new Ray(playerWhoSentMessage.gameplayCamera.transform.position, playerWhoSentMessage.gameplayCamera.transform.forward), out var hitInfo, 3f, 2816))
+                ChatCommandsManager.RegisterCommandForState<ChillWithPlayerState>(new ChatCommand(cmd, (state, lethalBotAI, playerWhoSentMessage, message, isVoice) =>
                 {
+                    lethalBotAI.State = new GrabLoadoutState(state);
                     return true;
-                }
+                }));
+            }
 
-                // Get the door object from the raycast
-                DoorLock lockedDoor = hitInfo.transform.GetComponent<DoorLock>();
-                if (lockedDoor == null)
+            foreach (string cmd in Const.USE_KEY_COMMANDS)
+            {
+                ChatCommandsManager.RegisterCommandForState<ChillWithPlayerState>(new ChatCommand(cmd, (state, lethalBotAI, playerWhoSentMessage, message, isVoice) =>
                 {
-                    TriggerPointToDoor component = hitInfo.transform.GetComponent<TriggerPointToDoor>();
-                    if (component != null)
+                    // Make sure we have a key or lockpicker
+                    // Check what door the player is looking at
+                    if (!lethalBotAI.HasKeyInInventory()
+                        || !Physics.Raycast(new Ray(playerWhoSentMessage.gameplayCamera.transform.position, playerWhoSentMessage.gameplayCamera.transform.forward), out var hitInfo, 3f, 2816))
                     {
-                        lockedDoor = component.pointToDoor;
+                        return true;
                     }
-                }
 
-                // If the door is locked, we better open it!
-                if (lockedDoor != null && lockedDoor.isLocked && !lockedDoor.isPickingLock)
-                {
-                    lethalBotAI.State = new UseKeyOnLockedDoorState(state, lockedDoor);
-                }
-                return true;
-            }));
+                    // Get the door object from the raycast
+                    DoorLock lockedDoor = hitInfo.transform.GetComponent<DoorLock>();
+                    if (lockedDoor == null)
+                    {
+                        TriggerPointToDoor component = hitInfo.transform.GetComponent<TriggerPointToDoor>();
+                        if (component != null)
+                        {
+                            lockedDoor = component.pointToDoor;
+                        }
+                    }
+
+                    // If the door is locked, we better open it!
+                    if (lockedDoor != null && lockedDoor.isLocked && !lockedDoor.isPickingLock)
+                    {
+                        lethalBotAI.State = new UseKeyOnLockedDoorState(state, lockedDoor);
+                    }
+                    return true;
+                }));
+            }
         }
 
         /// <inheritdoc cref="AIState.RegisterSignalTranslatorCommands"/>

--- a/AI/AIStates/MissionControlState.cs
+++ b/AI/AIStates/MissionControlState.cs
@@ -2146,112 +2146,127 @@ namespace LethalBots.AI.AIStates
             ChatCommandsManager.RegisterIgnoreDefaultForState<MissionControlState>();
 
             // Someone requested that we start the ship!
-            ChatCommandsManager.RegisterCommandForState<MissionControlState>(new ChatCommand(Const.START_THE_SHIP_COMMAND, (state, lethalBotAI, playerWhoSentMessage, message, isVoice) =>
+            foreach (string cmd in Const.START_THE_SHIP_COMMANDS)
             {
-                // Make sure the sender is valid!
-                if (playerWhoSentMessage == null)
+                ChatCommandsManager.RegisterCommandForState<MissionControlState>(new ChatCommand(cmd, (state, lethalBotAI, playerWhoSentMessage, message, isVoice) =>
                 {
-                    return true;
-                }
-
-                // Now we need to do some safety checks first. Only the host can tell the bot to pull the lever.
-                // Unless they are dead!
-                MissionControlState missionControlState = (MissionControlState)state; // We have bigger problems if this cast fails!
-                PlayerControllerB? hostPlayer = LethalBotManager.HostPlayerScript;
-                if (hostPlayer == null
-                    || hostPlayer == playerWhoSentMessage
-                    || hostPlayer.isPlayerDead
-                    || !Plugin.Config.StartShipChatCommandProtection.Value)
-                {
-                    if (LethalBotManager.AreWeAtTheCompanyBuilding())
+                    // Make sure the sender is valid!
+                    if (playerWhoSentMessage == null)
                     {
-                        lethalBotAI.SendChatMessage($"Affirmative, I will start the ship in {Const.LETHAL_BOT_TIMER_LEAVE_PLANET} seconds and once everyone is onboard.");
+                        return true;
+                    }
+
+                    // Now we need to do some safety checks first. Only the host can tell the bot to pull the lever.
+                    // Unless they are dead!
+                    MissionControlState missionControlState = (MissionControlState)state; // We have bigger problems if this cast fails!
+                    PlayerControllerB? hostPlayer = LethalBotManager.HostPlayerScript;
+                    if (hostPlayer == null
+                        || hostPlayer == playerWhoSentMessage
+                        || hostPlayer.isPlayerDead
+                        || !Plugin.Config.StartShipChatCommandProtection.Value)
+                    {
+                        if (LethalBotManager.AreWeAtTheCompanyBuilding())
+                        {
+                            lethalBotAI.SendChatMessage($"Affirmative, I will start the ship in {Const.LETHAL_BOT_TIMER_LEAVE_PLANET} seconds and once everyone is onboard.");
+                        }
+                        else
+                        {
+                            lethalBotAI.SendChatMessage($"Affirmative, I will start the ship in {Const.LETHAL_BOT_TIMER_LEAVE_PLANET} seconds.");
+                        }
+                        missionControlState.playerRequestLeave = true;
                     }
                     else
                     {
-                        lethalBotAI.SendChatMessage($"Affirmative, I will start the ship in {Const.LETHAL_BOT_TIMER_LEAVE_PLANET} seconds.");
+                        lethalBotAI.SendChatMessage($"Sorry {playerWhoSentMessage.playerUsername}, but only the captain can tell me to start the ship!");
                     }
-                    missionControlState.playerRequestLeave = true;
-                }
-                else
-                {
-                    lethalBotAI.SendChatMessage($"Sorry {playerWhoSentMessage.playerUsername}, but only the captain can tell me to start the ship!");
-                }
-                return true;
-            }));
+                    return true;
+                }));
+            }
 
             // A player is requesting we monitor them
-            ChatCommandsManager.RegisterCommandForState<MissionControlState>(new ChatCommand(Const.REQUEST_MONITORING_COMMAND, (state, lethalBotAI, playerWhoSentMessage, message, isVoice) =>
+            foreach (string cmd in Const.REQUEST_MONITORING_COMMANDS)
             {
-                MissionControlState missionControlState = (MissionControlState)state; // We have bigger problems if this cast fails!
-                lethalBotAI.SendChatMessage($"Roger, I will only monitor you, {playerWhoSentMessage.playerUsername}.");
-                missionControlState.monitoredPlayer = playerWhoSentMessage;
-                return true;
-            }));
+                ChatCommandsManager.RegisterCommandForState<MissionControlState>(new ChatCommand(cmd, (state, lethalBotAI, playerWhoSentMessage, message, isVoice) =>
+                {
+                    MissionControlState missionControlState = (MissionControlState)state; // We have bigger problems if this cast fails!
+                    lethalBotAI.SendChatMessage($"Roger, I will only monitor you, {playerWhoSentMessage.playerUsername}.");
+                    missionControlState.monitoredPlayer = playerWhoSentMessage;
+                    return true;
+                }));
+            }
 
             // The player wants to stop being monitored
-            ChatCommandsManager.RegisterCommandForState<MissionControlState>(new ChatCommand(Const.CLEAR_MONITORING_COMMAND, (state, lethalBotAI, playerWhoSentMessage, message, isVoice) =>
+            foreach (string cmd in Const.CLEAR_MONITORING_COMMANDS)
             {
-                MissionControlState missionControlState = (MissionControlState)state; // We have bigger problems if this cast fails!
-                if (missionControlState.monitoredPlayer != playerWhoSentMessage)
+                ChatCommandsManager.RegisterCommandForState<MissionControlState>(new ChatCommand(cmd, (state, lethalBotAI, playerWhoSentMessage, message, isVoice) =>
                 {
-                    return true; // Ignore request cancellations from other players!
-                }
-                lethalBotAI.SendChatMessage("Understood, I will resume monitoring all crew members.");
-                missionControlState.monitoredPlayer = null;
-                return true;
-            }));
+                    MissionControlState missionControlState = (MissionControlState)state; // We have bigger problems if this cast fails!
+                    if (missionControlState.monitoredPlayer != playerWhoSentMessage)
+                    {
+                        return true; // Ignore request cancellations from other players!
+                    }
+                    lethalBotAI.SendChatMessage("Understood, I will resume monitoring all crew members.");
+                    missionControlState.monitoredPlayer = null;
+                    return true;
+                }));
+            }
 
             // This player wants to be teleported back to the ship
-            ChatCommandsManager.RegisterCommandForState<MissionControlState>(new ChatCommand(Const.REQUEST_TELEPORT_COMMAND, (state, lethalBotAI, playerWhoSentMessage, message, isVoice) =>
+            foreach (string cmd in Const.REQUEST_TELEPORT_COMMANDS)
             {
-                // Make sure we have a teleporter
-                if (ShipTeleporter == null)
+                ChatCommandsManager.RegisterCommandForState<MissionControlState>(new ChatCommand(cmd, (state, lethalBotAI, playerWhoSentMessage, message, isVoice) =>
                 {
-                    // Remind the player on their poor decision to not buy a teleporter.......
-                    lethalBotAI.SendChatMessage("What do you mean, \"TELEPORT ME\"! We don't own a teleporter!");
-                    return true;
-                }
+                    // Make sure we have a teleporter
+                    if (ShipTeleporter == null)
+                    {
+                        // Remind the player on their poor decision to not buy a teleporter.......
+                        lethalBotAI.SendChatMessage("What do you mean, \"TELEPORT ME\"! We don't own a teleporter!");
+                        return true;
+                    }
 
-                // Only add new requests!
-                MissionControlState missionControlState = (MissionControlState)state; // We have bigger problems if this cast fails!
-                if (!missionControlState.playersRequstedTeleport.Contains(playerWhoSentMessage))
-                {
-                    lethalBotAI.SendChatMessage("Hold on, I will teleport you back to the ship as soon as possible.");
-                    missionControlState.playersRequstedTeleport.Enqueue(playerWhoSentMessage);
-                }
-                return true;
-            }));
+                    // Only add new requests!
+                    MissionControlState missionControlState = (MissionControlState)state; // We have bigger problems if this cast fails!
+                    if (!missionControlState.playersRequstedTeleport.Contains(playerWhoSentMessage))
+                    {
+                        lethalBotAI.SendChatMessage("Hold on, I will teleport you back to the ship as soon as possible.");
+                        missionControlState.playersRequstedTeleport.Enqueue(playerWhoSentMessage);
+                    }
+                    return true;
+                }));
+            }
 
             // A player is asking us to get off the terminal,
             // probably so they can use it.
-            ChatCommandsManager.RegisterCommandForState<MissionControlState>(new ChatCommand(Const.HOP_OFF_THE_TERMINAL_COMMAND, (state, lethalBotAI, playerWhoSentMessage, message, isVoice) =>
+            foreach (string cmd in Const.HOP_OFF_THE_TERMINAL_COMMANDS)
             {
-                MissionControlState missionControlState = (MissionControlState)state; // We have bigger problems if this cast fails!
-                if (!missionControlState.playerRequestedTerminal)
+                ChatCommandsManager.RegisterCommandForState<MissionControlState>(new ChatCommand(cmd, (state, lethalBotAI, playerWhoSentMessage, message, isVoice) =>
                 {
-                    lethalBotAI.SendChatMessage("Understood, I am leaving the terminal now.");
+                    MissionControlState missionControlState = (MissionControlState)state; // We have bigger problems if this cast fails!
+                    if (!missionControlState.playerRequestedTerminal)
+                    {
+                        lethalBotAI.SendChatMessage("Understood, I am leaving the terminal now.");
+                    }
+                    missionControlState.playerRequestedTerminal = true;
+                    missionControlState.waitForTerminalTime = 0f;
+                    return true;
+                }));
+
+                    // A player is asking us to transmit a message
+                    ChatCommandsManager.RegisterCommandForState<MissionControlState>(new ChatCommand(Const.TRANSMIT_KEYWORD, (state, lethalBotAI, playerWhoSentMessage, message, isVoice) =>
+                    {
+                        // First we need to extract the message!
+                        // FIXME: There has to be a better way to do this!
+                        MissionControlState missionControlState = (MissionControlState)state; // We have bigger problems if this cast fails!
+                        int transmitIndex = message.IndexOf(Const.TRANSMIT_KEYWORD) + Const.TRANSMIT_KEYWORD_LENGTH;
+                        string messageToTransmit = message.Substring(transmitIndex).Trim();
+                        lethalBotAI.SendChatMessage($"Alright, I will relay, {messageToTransmit} to the rest of the crew.");
+
+                        // Queue the message to be sent!
+                        missionControlState.SendMessageUsingSignalTranslator(messageToTransmit, QueuePriority.High);
+                        return true;
+                    }));
                 }
-                missionControlState.playerRequestedTerminal = true;
-                missionControlState.waitForTerminalTime = 0f;
-                return true;
-            }));
-
-            // A player is asking us to transmit a message
-            ChatCommandsManager.RegisterCommandForState<MissionControlState>(new ChatCommand(Const.TRANSMIT_KEYWORD, (state, lethalBotAI, playerWhoSentMessage, message, isVoice) =>
-            {
-                // First we need to extract the message!
-                // FIXME: There has to be a better way to do this!
-                MissionControlState missionControlState = (MissionControlState)state; // We have bigger problems if this cast fails!
-                int transmitIndex = message.IndexOf(Const.TRANSMIT_KEYWORD) + Const.TRANSMIT_KEYWORD_LENGTH;
-                string messageToTransmit = message.Substring(transmitIndex).Trim();
-                lethalBotAI.SendChatMessage($"Alright, I will relay, {messageToTransmit} to the rest of the crew.");
-
-                // Queue the message to be sent!
-                missionControlState.SendMessageUsingSignalTranslator(messageToTransmit, QueuePriority.High);
-                return true;
-            }));
-        }
+            }
 
         /// <inheritdoc cref="AIState.RegisterSignalTranslatorCommands"/>
         public static new void RegisterSignalTranslatorCommands()

--- a/AI/AIStates/TransferLootState.cs
+++ b/AI/AIStates/TransferLootState.cs
@@ -242,10 +242,13 @@ namespace LethalBots.AI.AIStates
         /// <inheritdoc cref="AIState.RegisterChatCommands"/>
         public static new void RegisterChatCommands()
         {
-            ChatCommandsManager.RegisterCommandForState<TransferLootState>(new ChatCommand(Const.TRANSFER_LOOT_COMMAND, (state, lethalBotAI, playerWhoSentMessage, message, isVoice) =>
+            foreach (string cmd in Const.TRANSFER_LOOT_COMMANDS)
             {
-                return true; // We are already transferring loot, no need to respond to transfer loot messages
-            }));
+                ChatCommandsManager.RegisterCommandForState<TransferLootState>(new ChatCommand(cmd, (state, lethalBotAI, playerWhoSentMessage, message, isVoice) =>
+                {
+                    return true; // We are already transferring loot, no need to respond to transfer loot messages
+                }));
+            }
         }
 
         /// <remarks>

--- a/AI/LethalBotAI.cs
+++ b/AI/LethalBotAI.cs
@@ -1081,7 +1081,7 @@ namespace LethalBots.AI
 
             if (IsOwner)
             {
-                LethalBotIdentity.Voice.SetNewRandomCooldownAudio();
+                LethalBotIdentity.Voice.SetNewRandomCooldownAudio(LethalBotIdentity.Voice.LastVoiceState);
             }
 
             Plugin.LogDebug($"Lethal Bot {NpcController.Npc.playerUsername} detected noise noisePosition {noisePosition}, noiseLoudness {noiseLoudness}, timesPlayedInOneSpot {timesPlayedInOneSpot}, noiseID {noiseID}");
@@ -5803,16 +5803,15 @@ namespace LethalBots.AI
 
 
         [ServerRpc(RequireOwnership = false)]
-        public void PlayAudioServerRpc(string smallPathAudioClip, int enumTalkativeness)
+        public void PlayAudioServerRpc(string smallPathAudioClip, int enumTalkativeness, int enumResponsiveness)
         {
-            PlayAudioClientRpc(smallPathAudioClip, enumTalkativeness);
+            PlayAudioClientRpc(smallPathAudioClip, enumTalkativeness, enumResponsiveness);
         }
 
         [ClientRpc]
-        private void PlayAudioClientRpc(string smallPathAudioClip, int enumTalkativeness)
+        private void PlayAudioClientRpc(string smallPathAudioClip, int enumTalkativeness, int enumResponsiveness)
         {
-            if (enumTalkativeness == Plugin.Config.Talkativeness.Value
-                || LethalBotIdentity.Voice.CanPlayAudioAfterCooldown())
+            if (enumTalkativeness == Plugin.Config.Talkativeness.Value || enumResponsiveness == Plugin.Config.Responsiveness.Value || LethalBotIdentity.Voice.CanPlayAudioAfterCooldown())
             {
                 Managers.AudioManager.Instance.PlayAudio(smallPathAudioClip, LethalBotIdentity.Voice);
             }

--- a/AI/LethalBotVoice.cs
+++ b/AI/LethalBotVoice.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using UnityEngine;
 using UnityEngine.Events;
+using static UnityEngine.UIElements.Layout.LayoutDataStore;
 using AudioManager = LethalBots.Managers.AudioManager;
 using Random = System.Random;
 
@@ -68,9 +69,9 @@ namespace LethalBots.AI
             cooldownPlayAudio = cooldown;
         }
 
-        public void SetNewRandomCooldownAudio()
+        public void SetNewRandomCooldownAudio(EnumVoicesState voiceState)
         {
-            cooldownPlayAudio = GetRandomCooldown();
+            cooldownPlayAudio = GetRandomCooldown(voiceState);
         }
 
         public void ReduceCooldown(float time)
@@ -79,6 +80,7 @@ namespace LethalBots.AI
             if (cooldownPlayAudio > 0f)
             {
                 cooldownPlayAudio -= time;
+                Plugin.LogError("cooldownPlayAudio = " + cooldownPlayAudio + " | time = " + time);
             }
             if (cooldownPlayAudio < 0f)
             {
@@ -96,6 +98,16 @@ namespace LethalBots.AI
         public bool IsTalking()
         {
             return CurrentAudioSource.isPlaying || aboutToTalk;
+        }
+
+        /// <summary>
+        /// Returns true if the given voice state is controlled by the responsiveness slider.
+        /// Otherwise it is controlled by the talkativeness slider.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool IsResponsivenessState(EnumVoicesState voiceState)
+        {
+            return VoicesConst.ResponsivenessVoiceStates.Contains(voiceState);
         }
 
         /// <summary>
@@ -133,24 +145,41 @@ namespace LethalBots.AI
 
         public void TryPlayVoiceAudio(PlayVoiceParameters parameters)
         {
-            if (Plugin.Config.Talkativeness.Value == (int)EnumTalkativeness.NoTalking)
+            // Check the correct value depending on which slider controls this state
+            // Cooldown check in the 'is responsive' if statement, otherwise the responsive voice lines have no cooldown
+            if (IsResponsivenessState(parameters.VoiceState))
             {
-                return;
+                if (Plugin.Config.Responsiveness.Value == (int)EnumResponsiveness.NoResponses)
+                {
+                    return;
+                }
+
+                if (!CanPlayAudioAfterCooldown())
+                {
+                    return;
+                }
+            }
+            else
+            {
+                if (Plugin.Config.Talkativeness.Value == (int)EnumTalkativeness.NoTalking)
+                {
+                    return;
+                }
+
+                if (parameters.WaitForCooldown)
+                {
+                    if (!CanPlayAudioAfterCooldown())
+                    {
+                        return;
+                    }
+                }
             }
 
             if (!parameters.CanTalkIfOtherLethalBotTalk)
             {
                 if (LethalBotManager.Instance.DidAnLethalBotJustTalkedClose(this.BotID))
                 {
-                    SetNewRandomCooldownAudio();
-                    return;
-                }
-            }
-
-            if (parameters.WaitForCooldown)
-            {
-                if (!CanPlayAudioAfterCooldown())
-                {
+                    SetNewRandomCooldownAudio(parameters.VoiceState);
                     return;
                 }
             }
@@ -223,25 +252,51 @@ namespace LethalBots.AI
             CurrentAudioSource.clip = audioClip;
             CurrentAudioSource.Play();
 
-            SetCooldownAudio(audioClip.length + GetRandomCooldown());
+            float tmepfloat = GetRandomCooldown(LastVoiceState);
+            Plugin.LogError("responsive cooldown = " + tmepfloat);
+            SetCooldownAudio(audioClip.length + tmepfloat);
         }
 
-        private float GetRandomCooldown()
+        /// <summary>
+        /// Returns a random cooldown duration using whichever slider (talkativeness or responsiveness) controls <paramref name="voiceState"/>.
+        /// </summary>
+        private float GetRandomCooldown(EnumVoicesState voiceState)
         {
             // Set random cooldown
             Random randomInstance = new Random();
-            switch (Plugin.Config.Talkativeness.Value)
+            if (IsResponsivenessState(voiceState))
             {
-                case (int)EnumTalkativeness.Shy:
-                    return (float)randomInstance.Next(VoicesConst.MIN_COOLDOWN_PLAYVOICE_SHY, VoicesConst.MAX_COOLDOWN_PLAYVOICE_SHY);
-                case (int)EnumTalkativeness.Normal:
-                    return (float)randomInstance.Next(VoicesConst.MIN_COOLDOWN_PLAYVOICE_NORMAL, VoicesConst.MAX_COOLDOWN_PLAYVOICE_NORMAL);
-                case (int)EnumTalkativeness.Talkative:
-                    return (float)randomInstance.Next(VoicesConst.MIN_COOLDOWN_PLAYVOICE_TALKATIVE, VoicesConst.MAX_COOLDOWN_PLAYVOICE_TALKATIVE);
-                case (int)EnumTalkativeness.CantStopTalking:
-                    return (float)randomInstance.Next(VoicesConst.MIN_COOLDOWN_PLAYVOICE_CANTSTOPTALKING, VoicesConst.MAX_COOLDOWN_PLAYVOICE_CANTSTOPTALKING);
-                default:
-                    return 0f;
+                Plugin.LogError("is responsive");
+                switch (Plugin.Config.Responsiveness.Value)
+                {
+                    case (int)EnumResponsiveness.Shy:
+                        return (float)randomInstance.Next(VoicesConst.MIN_COOLDOWN_PLAYVOICE_RESPONSIVE_SHY, VoicesConst.MAX_COOLDOWN_PLAYVOICE_RESPONSIVE_SHY);
+                    case (int)EnumResponsiveness.Normal:
+                        return (float)randomInstance.Next(VoicesConst.MIN_COOLDOWN_PLAYVOICE_RESPONSIVE_NORMAL, VoicesConst.MAX_COOLDOWN_PLAYVOICE_RESPONSIVE_NORMAL);
+                    case (int)EnumResponsiveness.Responsive:
+                        return (float)randomInstance.Next(VoicesConst.MIN_COOLDOWN_PLAYVOICE_RESPONSIVE_RESPONSIVE, VoicesConst.MAX_COOLDOWN_PLAYVOICE_RESPONSIVE_RESPONSIVE);
+                    case (int)EnumResponsiveness.AlwaysRespond:
+                        return (float)randomInstance.Next(VoicesConst.MIN_COOLDOWN_PLAYVOICE_RESPONSIVE_ALWAYSRESPOND, VoicesConst.MAX_COOLDOWN_PLAYVOICE_RESPONSIVE_ALWAYSRESPOND);
+                    default:
+                        Plugin.LogError("responsive used default value");
+                        return 0f;
+                }
+            } else
+            {
+                Plugin.LogError("is talkative");
+                switch (Plugin.Config.Talkativeness.Value)
+                {
+                    case (int)EnumTalkativeness.Shy:
+                        return (float)randomInstance.Next(VoicesConst.MIN_COOLDOWN_PLAYVOICE_SHY, VoicesConst.MAX_COOLDOWN_PLAYVOICE_SHY);
+                    case (int)EnumTalkativeness.Normal:
+                        return (float)randomInstance.Next(VoicesConst.MIN_COOLDOWN_PLAYVOICE_NORMAL, VoicesConst.MAX_COOLDOWN_PLAYVOICE_NORMAL);
+                    case (int)EnumTalkativeness.Talkative:
+                        return (float)randomInstance.Next(VoicesConst.MIN_COOLDOWN_PLAYVOICE_TALKATIVE, VoicesConst.MAX_COOLDOWN_PLAYVOICE_TALKATIVE);
+                    case (int)EnumTalkativeness.CantStopTalking:
+                        return (float)randomInstance.Next(VoicesConst.MIN_COOLDOWN_PLAYVOICE_CANTSTOPTALKING, VoicesConst.MAX_COOLDOWN_PLAYVOICE_CANTSTOPTALKING);
+                    default:
+                        return 0f;
+                }
             }
         }
 

--- a/Configs/Config.cs
+++ b/Configs/Config.cs
@@ -62,6 +62,7 @@ namespace LethalBots.Configs
 
         // Voices
         public ConfigEntry<int> Talkativeness;
+        public ConfigEntry<int> Responsiveness;
         public ConfigEntry<bool> AllowSwearing;
         [SyncedEntryField] public SyncedEntry<bool> AllowTalkingWhileDead;
 
@@ -234,9 +235,23 @@ namespace LethalBots.Configs
             Talkativeness = cfg.Bind(ConfigConst.ConfigSectionVoices,
                                      "Talkativeness (Client only)",
                                      defaultValue: (int)VoicesConst.DEFAULT_CONFIG_ENUM_TALKATIVENESS,
-                                     new ConfigDescription("0: No talking | 1: Shy | 2: Normal | 3: Talkative | 4: Can't stop talking",
+                                     new ConfigDescription(
+                                            "Controls how often bots play idle/ambient voice lines " +
+                                            "(When waiting, founding Loot, getting lost, hearing the player etc.). " +
+                                            "0: No talking | 1: Shy | 2: Normal | 3: Talkative | 4: Can't stop talking",
                                                      new AcceptableValueRange<int>(Enum.GetValues(typeof(EnumTalkativeness)).Cast<int>().Min(),
                                                                                    Enum.GetValues(typeof(EnumTalkativeness)).Cast<int>().Max())));
+
+            Responsiveness = cfg.Bind(ConfigConst.ConfigSectionVoices,
+                                      "Responsiveness (Client only)",
+                                      defaultValue: (int)VoicesConst.DEFAULT_CONFIG_ENUM_RESPONSIVENESS,
+                                      new ConfigDescription(
+                                            "Controls how often bots react to events with voice lines " +
+                                            "(When hit, running from a monster, attacking, ordered to follow, stepped on a trap, etc.). " +
+                                            "0: No responses | 1: Shy | 2: Normal | 3: Responsive | 4: Always respond",
+                                            new AcceptableValueRange<int>(
+                                                Enum.GetValues(typeof(EnumResponsiveness)).Cast<int>().Min(),
+                                                Enum.GetValues(typeof(EnumResponsiveness)).Cast<int>().Max())));
 
             AllowSwearing = cfg.Bind(ConfigConst.ConfigSectionVoices,
                                      "Swear words (Client only)",

--- a/Constants/Const.cs
+++ b/Constants/Const.cs
@@ -137,18 +137,22 @@ namespace LethalBots.Constants
         // Chat command consts
         // Its a good idea to use consts for your chat command names!
         public const string JESTER_COMMAND = "jester";
-        public const string MAN_THE_SHIP_COMMAND = "man the ship";
-        public const string TRANSFER_LOOT_COMMAND = "transfer loot";
-        public const string GEAR_UP_COMMAND = "gear up";
-        public const string START_THE_SHIP_COMMAND = "start the ship";
-        public const string REQUEST_MONITORING_COMMAND = "request monitoring";
-        public const string CLEAR_MONITORING_COMMAND = "clear monitoring";
-        public const string REQUEST_TELEPORT_COMMAND = "request teleport";
-        public const string HOP_OFF_THE_TERMINAL_COMMAND = "hop off the terminal";
-        public const string USE_KEY_COMMAND = "use key";
         public const string JOIN_GROUP_COMMAND = "join group";
         public const string LEAVE_GROUP_COMMAND = "leave group";
         public const string CREATE_GROUP_COMMAND = "create group";
+
+        // Chat command static readonly arrays
+        public static readonly string[] MAN_THE_SHIP_COMMANDS = { "man the ship", "get on the terminal" };
+        public static readonly string[] TRANSFER_LOOT_COMMANDS = { "transfer loot", "transfer items", "transfer scrap" };
+        public static readonly string[] GEAR_UP_COMMANDS = { "gear up", "get your gear", "pick up your gear" };
+        public static readonly string[] START_THE_SHIP_COMMANDS = { "start the ship", "land the ship", "take off", "pull the lever" };
+        public static readonly string[] REQUEST_MONITORING_COMMANDS = { "request monitoring", "monitor me" };
+        public static readonly string[] CLEAR_MONITORING_COMMANDS = { "clear monitoring", "stop monitoring" };
+        // You probably want to be teleported in dangerous situations and 'help fast' and 'help me' fit that.
+        // 'help' might be too short for a command as then it might trigger too much.
+        public static readonly string[] REQUEST_TELEPORT_COMMANDS = { "request teleport", "teleport me", "help fast", "help me" };
+        public static readonly string[] HOP_OFF_THE_TERMINAL_COMMANDS = { "hop off the terminal", "get off the terminal", "get off" };
+        public static readonly string[] USE_KEY_COMMANDS = { "use key", "open the door", "unlock the door" };
 
         // Signal Translator command consts
         public const string RETURN_COMMAND = "return";

--- a/Constants/VoicesConst.cs
+++ b/Constants/VoicesConst.cs
@@ -1,16 +1,20 @@
 ﻿using LethalBots.Enums;
+using System.Collections.Generic;
 
 namespace LethalBots.Constants
 {
     public class VoicesConst
     {
         public const EnumTalkativeness DEFAULT_CONFIG_ENUM_TALKATIVENESS = EnumTalkativeness.Normal;
+        public const EnumResponsiveness DEFAULT_CONFIG_ENUM_RESPONSIVENESS = EnumResponsiveness.Normal;
 
         public const float DISTANCE_HEAR_OTHER_BOTS = 10f;
         public const string SWEAR_KEYWORD = "_cuss";
         public const string INSIDE_KEYWORD = "_inside";
         public const string OUTSIDE_KEYWORD = "_outside";
 
+        // Talkativeness cooldowns
+        // in seconds
         public const int MIN_COOLDOWN_PLAYVOICE_SHY = 10;
         public const int MAX_COOLDOWN_PLAYVOICE_SHY = 40;
 
@@ -22,5 +26,35 @@ namespace LethalBots.Constants
 
         public const int MIN_COOLDOWN_PLAYVOICE_CANTSTOPTALKING = 0;
         public const int MAX_COOLDOWN_PLAYVOICE_CANTSTOPTALKING = 0;
+
+        // Responsiveness cooldowns
+        // in seconds
+        public const int MIN_COOLDOWN_PLAYVOICE_RESPONSIVE_SHY = 8;
+        public const int MAX_COOLDOWN_PLAYVOICE_RESPONSIVE_SHY = 28;
+
+        public const int MIN_COOLDOWN_PLAYVOICE_RESPONSIVE_NORMAL = 4;
+        public const int MAX_COOLDOWN_PLAYVOICE_RESPONSIVE_NORMAL = 14;
+
+        public const int MIN_COOLDOWN_PLAYVOICE_RESPONSIVE_RESPONSIVE = 2;
+        public const int MAX_COOLDOWN_PLAYVOICE_RESPONSIVE_RESPONSIVE = 7;
+
+        public const int MIN_COOLDOWN_PLAYVOICE_RESPONSIVE_ALWAYSRESPOND = 0;
+        public const int MAX_COOLDOWN_PLAYVOICE_RESPONSIVE_ALWAYSRESPOND = 0;
+
+        /// <summary>
+        /// Voice states that are driven by the responsiveness slider
+        /// Everything NOT in this set is driven by the Talkativeness slider
+        /// </summary>
+        public static readonly HashSet<EnumVoicesState> ResponsivenessVoiceStates = new HashSet<EnumVoicesState>
+        {
+            EnumVoicesState.AttackingWithGun,
+            EnumVoicesState.AttackingWithMelee,
+            EnumVoicesState.Hit,
+            EnumVoicesState.OrderedToFollow,
+            EnumVoicesState.OrderedToStay,
+            EnumVoicesState.RunningFromMonster,
+            EnumVoicesState.Sinking,
+            EnumVoicesState.SteppedOnTrap,
+        };
     }
 }

--- a/Enums/EnumResponsiveness.cs
+++ b/Enums/EnumResponsiveness.cs
@@ -1,0 +1,11 @@
+﻿namespace LethalBots.Enums
+{
+    public enum EnumResponsiveness
+    {
+        NoResponses,
+        Shy,
+        Normal,
+        Responsive,
+        AlwaysRespond
+    }
+}

--- a/Managers/LethalBotManager.cs
+++ b/Managers/LethalBotManager.cs
@@ -5320,7 +5320,7 @@ namespace LethalBots.Managers
 
         public void SyncPlayAudioLethalBot(int lethalBotID, string smallPathAudioClip)
         {
-            AllLethalBotAIs[lethalBotID].PlayAudioServerRpc(smallPathAudioClip, Plugin.Config.Talkativeness.Value);
+            AllLethalBotAIs[lethalBotID].PlayAudioServerRpc(smallPathAudioClip, Plugin.Config.Talkativeness.Value, Plugin.Config.Responsiveness.Value);
         }
 
         public void PlayAudibleNoiseForLethalBot(int lethalBotID,


### PR DESCRIPTION
### Commit fcceafd

Previously, all bot chat commands were single hardcoded strings, meaning players had to use exact phrasing to command the bots. This made communication feel robotic.

I have changed the following commands into `static readonly string[]` instead of `const string`:
- MAN_THE_SHIP_COMMAND
- TRANSFER_LOOT_COMMAND
- GEAR_UP_COMMAND
- START_THE_SHIP_COMMAND
- REQUEST_MONITORING_COMMAND
- CLEAR_MONITORING_COMMAND
- REQUEST_TELEPORT_COMMAND
- HOP_OFF_THE_TERMINAL_COMMAND
- USE_KEY_COMMAND

This gives each command multiple valid phrases, allowing less robotic communication with the bots. 
The multiple valid phrases also allows players to not have to memorize the exact sentences as variations exist that will still trigger the same command.

### Commit 2f90aab
Previously, the Talkativeness controlled all voice lines. ~3 weeks from writing this, I made an issue post talking about separating the voice lines in two categories. [This was that issue post.](https://github.com/T-Rizzle12/Lethal-Bots/issues/94)

I have now made the changes needed in order for that to work. 