### PR TITLE
'Talkativeness' & 'Responsiveness' int to enum

### DIFF
--- a/AI/LethalBotAI.cs
+++ b/AI/LethalBotAI.cs
@@ -5847,13 +5847,13 @@ namespace LethalBots.AI
 
 
         [ServerRpc(RequireOwnership = false)]
-        public void PlayAudioServerRpc(string smallPathAudioClip, int enumTalkativeness, int enumResponsiveness)
+        public void PlayAudioServerRpc(string smallPathAudioClip, EnumTalkativeness enumTalkativeness, EnumResponsiveness enumResponsiveness)
         {
             PlayAudioClientRpc(smallPathAudioClip, enumTalkativeness, enumResponsiveness);
         }
 
         [ClientRpc]
-        private void PlayAudioClientRpc(string smallPathAudioClip, int enumTalkativeness, int enumResponsiveness)
+        private void PlayAudioClientRpc(string smallPathAudioClip, EnumTalkativeness enumTalkativeness, EnumResponsiveness enumResponsiveness)
         {
             if (enumTalkativeness == Plugin.Config.Talkativeness.Value || enumResponsiveness == Plugin.Config.Responsiveness.Value || LethalBotIdentity.Voice.CanPlayAudioAfterCooldown(LethalBotIdentity.Voice.LastVoiceState))
             {

--- a/AI/LethalBotVoice.cs
+++ b/AI/LethalBotVoice.cs
@@ -319,13 +319,13 @@ namespace LethalBots.AI
             {
                 switch (Plugin.Config.Responsiveness.Value)
                 {
-                    case (int)EnumResponsiveness.Shy:
+                    case EnumResponsiveness.Shy:
                         return Random.Range(VoicesConst.MIN_COOLDOWN_PLAYVOICE_RESPONSIVE_SHY, VoicesConst.MAX_COOLDOWN_PLAYVOICE_RESPONSIVE_SHY);
-                    case (int)EnumResponsiveness.Normal:
+                    case EnumResponsiveness.Normal:
                         return Random.Range(VoicesConst.MIN_COOLDOWN_PLAYVOICE_RESPONSIVE_NORMAL, VoicesConst.MAX_COOLDOWN_PLAYVOICE_RESPONSIVE_NORMAL);
-                    case (int)EnumResponsiveness.Responsive:
+                    case EnumResponsiveness.Responsive:
                         return Random.Range(VoicesConst.MIN_COOLDOWN_PLAYVOICE_RESPONSIVE_RESPONSIVE, VoicesConst.MAX_COOLDOWN_PLAYVOICE_RESPONSIVE_RESPONSIVE);
-                    case (int)EnumResponsiveness.AlwaysRespond:
+                    case EnumResponsiveness.AlwaysRespond:
                         return Random.Range(VoicesConst.MIN_COOLDOWN_PLAYVOICE_RESPONSIVE_ALWAYSRESPOND, VoicesConst.MAX_COOLDOWN_PLAYVOICE_RESPONSIVE_ALWAYSRESPOND);
                     default:
                         return 0f;
@@ -335,13 +335,13 @@ namespace LethalBots.AI
             {
                 switch (Plugin.Config.Talkativeness.Value)
                 {
-                    case (int)EnumTalkativeness.Shy:
+                    case EnumTalkativeness.Shy:
                         return Random.Range(VoicesConst.MIN_COOLDOWN_PLAYVOICE_SHY, VoicesConst.MAX_COOLDOWN_PLAYVOICE_SHY);
-                    case (int)EnumTalkativeness.Normal:
+                    case EnumTalkativeness.Normal:
                         return Random.Range(VoicesConst.MIN_COOLDOWN_PLAYVOICE_NORMAL, VoicesConst.MAX_COOLDOWN_PLAYVOICE_NORMAL);
-                    case (int)EnumTalkativeness.Talkative:
+                    case EnumTalkativeness.Talkative:
                         return Random.Range(VoicesConst.MIN_COOLDOWN_PLAYVOICE_TALKATIVE, VoicesConst.MAX_COOLDOWN_PLAYVOICE_TALKATIVE);
-                    case (int)EnumTalkativeness.CantStopTalking:
+                    case EnumTalkativeness.CantStopTalking:
                         return Random.Range(VoicesConst.MIN_COOLDOWN_PLAYVOICE_CANTSTOPTALKING, VoicesConst.MAX_COOLDOWN_PLAYVOICE_CANTSTOPTALKING);
                     default:
                         return 0f;

--- a/Configs/Config.cs
+++ b/Configs/Config.cs
@@ -61,8 +61,8 @@ namespace LethalBots.Configs
         public ConfigEntry<float> VoiceRecognitionSimilarityThreshold;
 
         // Voices
-        public ConfigEntry<int> Talkativeness;
-        public ConfigEntry<int> Responsiveness;
+        public ConfigEntry<EnumTalkativeness> Talkativeness;
+        public ConfigEntry<EnumResponsiveness> Responsiveness;
         public ConfigEntry<bool> AllowSwearing;
         [SyncedEntryField] public SyncedEntry<bool> AllowTalkingWhileDead;
 
@@ -234,25 +234,19 @@ namespace LethalBots.Configs
             // Voices
             Talkativeness = cfg.Bind(ConfigConst.ConfigSectionVoices,
                                         "Talkativeness (Client only)",
-                                        defaultValue: (int)VoicesConst.DEFAULT_CONFIG_ENUM_TALKATIVENESS,
+                                        defaultValue: VoicesConst.DEFAULT_CONFIG_ENUM_TALKATIVENESS,
                                         new ConfigDescription(
-                                            "Controls how often bots play idle/ambient voice lines " +
-                                            "(When waiting, founding Loot, getting lost, hearing the player etc.). " +
-                                            "0: No talking | 1: Shy | 2: Normal | 3: Talkative | 4: Can't stop talking",
-                                                new AcceptableValueRange<int>(
-                                                    Enum.GetValues(typeof(EnumTalkativeness)).Cast<int>().Min(), 
-                                                    Enum.GetValues(typeof(EnumTalkativeness)).Cast<int>().Max())));
+                                            "Controls how often bots play idle or ambient voice lines " +
+                                            "(When waiting, founding Loot, getting lost, hearing the player etc.)."
+                                        ));
 
             Responsiveness = cfg.Bind(ConfigConst.ConfigSectionVoices,
                                         "Responsiveness (Client only)",
-                                        defaultValue: (int)VoicesConst.DEFAULT_CONFIG_ENUM_RESPONSIVENESS,
+                                        defaultValue: VoicesConst.DEFAULT_CONFIG_ENUM_RESPONSIVENESS,
                                         new ConfigDescription(
                                             "Controls how often bots react to events with voice lines " +
-                                            "(When hit, running from a monster, attacking, ordered to follow, stepped on a trap, etc.). " +
-                                            "0: No responses | 1: Shy | 2: Normal | 3: Responsive | 4: Always respond",
-                                                new AcceptableValueRange<int>(
-                                                    Enum.GetValues(typeof(EnumResponsiveness)).Cast<int>().Min(),
-                                                    Enum.GetValues(typeof(EnumResponsiveness)).Cast<int>().Max())));
+                                            "(When hit, running from a monster, attacking, ordered to follow, stepped on a trap, etc.)."
+                                        ));
 
             AllowSwearing = cfg.Bind(ConfigConst.ConfigSectionVoices,
                                      "Swear words (Client only)",

--- a/Enums/EnumResponsiveness.cs
+++ b/Enums/EnumResponsiveness.cs
@@ -1,6 +1,6 @@
 ﻿namespace LethalBots.Enums
 {
-    public enum EnumResponsiveness
+    public enum EnumResponsiveness : byte
     {
         NoResponses,
         Shy,

--- a/Enums/EnumTalkativeness.cs
+++ b/Enums/EnumTalkativeness.cs
@@ -1,6 +1,6 @@
 ﻿namespace LethalBots.Enums
 {
-    public enum EnumTalkativeness
+    public enum EnumTalkativeness : byte
     {
         NoTalking,
         Shy,


### PR DESCRIPTION
The config can handle enum values. 
Using enum values will cause a dropdown menu to appear for the option instead of a slider.

Having a dropdown looks cleaner and the user can immediately see what value the option is set at without needing to read the description.

<img width="813" height="190" alt="image" src="https://github.com/user-attachments/assets/20f3e1b0-3366-4c22-abd4-846dea1b2287" />

<br>
<br>
Using a enum value for the config also removes the need for the casts to int.

In terms of networking, using a enum vs a int does not make any difference, but with the ': byte' in the enum class, it slightly reduces the bandwidth needed to send to clients. Not that that is anything major or anything.

This is just a small change, so I don't know if you want an update for this or if you want to wait so it can be included in a future update alongside with other stuff.