### PR TITLE
10.1.0 Bug Fixes

### DIFF
--- a/AI/LethalBotAI.cs
+++ b/AI/LethalBotAI.cs
@@ -568,7 +568,7 @@ namespace LethalBots.AI
                         // Do the AI calculation behaviour for the current state
                         State.DoAI();
                         State.TryPlayCurrentStateVoiceAudio();
-                        updateDestinationIntervalLethalBotAI = AIIntervalTime;
+                        updateDestinationIntervalLethalBotAI = AIIntervalTime + UnityEngine.Random.Range(-0.015f, 0.015f);
                     }
                 }
                 else if (lethalBotController.isPlayerDead)
@@ -790,7 +790,7 @@ namespace LethalBots.AI
 
                 // Do the actual AI calculation
                 DoAIInterval();
-                updateDestinationIntervalLethalBotAI = AIIntervalTime;
+                updateDestinationIntervalLethalBotAI = AIIntervalTime + UnityEngine.Random.Range(-0.015f, 0.015f);
             }
         }
 
@@ -811,6 +811,9 @@ namespace LethalBots.AI
             {
                 return;
             }
+
+            // Update area costs for bots
+            SetAreaCostsForBot();
 
             // Do the AI calculation behaviour for the current state
             State.DoAI();
@@ -930,10 +933,11 @@ namespace LethalBots.AI
             }
 
             Vector3 externalForces = lethalBotController.externalForces;
-            float externalForces2 = externalForces.x * externalForces.x + externalForces.z * externalForces.z;
-            if (externalForces2 > 4f * 4f || externalForces.y > 7.1f)
+            Vector3 previousExternalForces = NpcController.PreviousExternalForces;
+            if (externalForces.sqrMagnitude > 2f * 2f 
+                || previousExternalForces.sqrMagnitude > 2f * 2f)
             {
-                Plugin.LogDebug($"{lethalBotController.playerUsername} externalForces {externalForces}");
+                Plugin.LogDebug($"{lethalBotController.playerUsername} externalForces {externalForces.sqrMagnitude} previousExternalForces {previousExternalForces}");
                 return true;
             }
 
@@ -2253,28 +2257,47 @@ namespace LethalBots.AI
             return false;
         }
 
+        /// <summary>
+        /// Enables or disables the bot's <see cref="EnemyAI.agent"/>
+        /// </summary>
+        /// <remarks>
+        /// This calls <see cref="SetAreaCostsForBot"/> internally
+        /// </remarks>
+        /// <param name="enabled"></param>
         public void SetAgent(bool enabled)
         {
             if (agent != null && agent.enabled != enabled)
             {
                 agent.enabled = enabled;
-                if (enabled && agent.isOnNavMesh) // Make sure the agent is enabled before setting area costs
+                if (enabled)
                 {
-                    // 10 times the pathing cost for water!
-                    int waterArea = NavMesh.GetAreaFromName("Water");
-                    agent.SetAreaCost(waterArea, 10f);
-
-                    // High path cost for enemy only area
-                    // NOTE: I can't tell the bots to not path here, or they could break on some custom moons!
-                    int enemyOnlyArea = NavMesh.GetAreaFromName("EnemiesOnly");
-                    agent.SetAreaCost(enemyOnlyArea, 50f);
-
-                    // 5 times the pathing cost for landmines!
-                    agent.SetAreaCost(Const.LETHAL_BOT_LANDMINE_NAVAREA, 5f);
-
-                    // High path cost for quicksand
-                    agent.SetAreaCost(Const.LETHAL_BOT_QUICKSAND_NAVAREA, 50f);
+                    SetAreaCostsForBot();
                 }
+            }
+        }
+
+        /// <summary>
+        /// This helper applies the preset area costs for the bots
+        /// </summary>
+        public void SetAreaCostsForBot()
+        {
+            // Make sure the agent is enabled before setting area costs
+            if (agent.enabled && agent.isOnNavMesh)
+            {
+                // 10 times the pathing cost for water!
+                int waterArea = NavMesh.GetAreaFromName("Water");
+                agent.SetAreaCost(waterArea, 10f);
+
+                // High path cost for enemy only area
+                // NOTE: I can't tell the bots to not path here, or they could break on some custom moons!
+                int enemyOnlyArea = NavMesh.GetAreaFromName("EnemiesOnly");
+                agent.SetAreaCost(enemyOnlyArea, 100f);
+
+                // 5 times the pathing cost for landmines!
+                agent.SetAreaCost(Const.LETHAL_BOT_LANDMINE_NAVAREA, 5f);
+
+                // High path cost for quicksand
+                agent.SetAreaCost(Const.LETHAL_BOT_QUICKSAND_NAVAREA, 100f);
             }
         }
 

--- a/AI/NpcController.cs
+++ b/AI/NpcController.cs
@@ -45,6 +45,7 @@ namespace LethalBots.AI
         public AudioLowPassFilter AudioLowPassFilterComponent = null!;
         public AudioHighPassFilter AudioHighPassFilterComponent = null!;
 
+        public Vector3 PreviousExternalForces { get; private set; }
         public Vector3 MoveVector;
         public bool IsTouchingGround;
         public EnemyAI? EnemyInAnimationWith;
@@ -224,6 +225,7 @@ namespace LethalBots.AI
                     // Check if the bot is falling and update values accordingly
                     UpdateFallValuesForOwner();
 
+                    PreviousExternalForces = lethalBotController.externalForces;
                     lethalBotController.externalForces = Vector3.zero;
                     if (!lethalBotController.teleportingThisFrame && lethalBotController.teleportedLastFrame)
                     {
@@ -957,18 +959,17 @@ namespace LethalBots.AI
         {
             PlayerControllerB lethalBotController = Npc;
             Vector3 direction = lethalBotController.thisPlayerBody.up;
-            Vector3 origin = lethalBotController.gameplayCamera.transform.position + lethalBotController.thisPlayerBody.up * 0.07f;
             if ((lethalBotController.externalForces + lethalBotController.externalForceAutoFade).sqrMagnitude > 8f * 8f)
             {
                 lethalBotController.CancelSpecialTriggerAnimations();
             }
+            PreviousExternalForces = lethalBotController.externalForces;
             lethalBotController.externalForces = Vector3.zero;
             lethalBotController.externalForceAutoFade = Vector3.Lerp(lethalBotController.externalForceAutoFade, Vector3.zero, 5f * Time.deltaTime);
 
             if (goDownLadder)
             {
                 direction = -lethalBotController.thisPlayerBody.up;
-                origin = lethalBotController.transform.position;
             }
             lethalBotController.thisPlayerBody.transform.position += direction * (Const.BASE_MAX_SPEED * lethalBotController.climbSpeed * Time.deltaTime);
             //if (!Physics.Raycast(origin, direction, 0.15f, StartOfRound.Instance.allPlayersCollideWithMask, QueryTriggerInteraction.Ignore))

--- a/Configs/Config.cs
+++ b/Configs/Config.cs
@@ -71,6 +71,7 @@ namespace LethalBots.Configs
 
         // Debug
         public ConfigEntry<bool> EnableDebugLog;
+        [SyncedEntryField] public SyncedEntry<bool> UseOldChatRecevier;
 
         // Mod Related Settings
         [SyncedEntryField] public SyncedEntry<bool> AllowRandomCalling;
@@ -284,6 +285,11 @@ namespace LethalBots.Configs
                                       "EnableDebugLog  (Client only)",
                                       defaultValue: true,
                                       "Enable the debug logs used for this mod.");
+
+            UseOldChatRecevier = cfg.BindSyncedEntry(ConfigConst.ConfigSectionDebug,
+                                      "Use Old Chat Recevier",
+                                      defaultVal: false,
+                                      "Should the old chat recevier be used instead of the new one! YOU SHOULD ONLY ENABLE THIS IF CHAT COMMANDS ARE NOT WORKING!");
 
             // Mod Related Settings
             AllowRandomCalling = cfg.BindSyncedEntry(ConfigConst.ConfigSectionMods, 

--- a/LethalBot.csproj
+++ b/LethalBot.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>LethalBots</AssemblyName>
     <Product>LethalBots</Product>
     <!-- Change to whatever version you're currently on. This will be used by tcli when building our Thunderstore package. -->
-    <Version>10.0.0</Version>
+    <Version>10.1.0</Version>
   </PropertyGroup>
 
   <!-- Project Properties -->

--- a/Managers/LethalBotManager.cs
+++ b/Managers/LethalBotManager.cs
@@ -2623,7 +2623,7 @@ namespace LethalBots.Managers
                     if (AreWeInOrbit() && Plugin.Config.AllowBotsInOrbit.Value)
                     {
                         EnsureShipNavMeshBuilt();
-                        EnableShipNavMesh();
+                        EnableShipNavMesh(reason: "Bots spawning in orbit!");
                         SpawnLethalBotsAtShip(markBotsAsLoaded: true);
                     }
                     else
@@ -2736,7 +2736,7 @@ namespace LethalBots.Managers
                 }
                 //else if (message.Contains("get navarea"))
                 //{
-                //    if (NavMesh.SamplePosition(playerWhoSentMessage.transform.position, out RoundManager.Instance.navHit, 30f, 1 << Const.LETHAL_BOT_QUICKSAND_NAVAREA))
+                //    if (NavMesh.SamplePosition(playerWhoSentMessage.transform.position, out RoundManager.Instance.navHit, 30f, 1 << NavMesh.GetAreaFromName("EnemiesOnly")))
                 //    {
                 //        HUDManager.Instance.AddTextToChatOnServer($"Found NavArea: {RoundManager.Instance.navHit.position}. Distance to Player {Vector3.Distance(playerWhoSentMessage.transform.position, RoundManager.Instance.navHit.position)}");
                 //        HUDManager.Instance.AddTextToChatOnServer($"Area mask: {RoundManager.Instance.navHit.mask}");
@@ -3639,16 +3639,14 @@ namespace LethalBots.Managers
                         // NOTE: We do this here as other clients will have a spawn miscount if we don't!
                         // HACKHACK: We raise the connected players amount and number of living players so enemies consider them!
                         // This also makes it so if all human players die, the bots can continue without them!
-                        newPlayerCount += 1;
-                        newLivingPlayerCount += 1;
+                        newPlayerCount++;
+                        newLivingPlayerCount++;
                         nbSpawnedBots++;
                     }
                     else if (botSpawned.Value == EnumBotSpawnState.NotSpawned)
                     {
                         Plugin.LogError("Failed to spawn bot on the host!");
                     }
-                    // NEEDTOVALIDATE: Should this be faster!
-                    //yield return new WaitForSeconds(0.3f);
                 }
             }
             Plugin.LogDebug("Finished spawning bots!");
@@ -5376,7 +5374,7 @@ namespace LethalBots.Managers
             if (AreWeInOrbit())
             {
                 EnsureShipNavMeshBuilt();
-                EnableShipNavMesh();
+                EnableShipNavMesh(reason: "Client joining ship in orbit!");
             }
 
             // We use a coroutine to guarantee the bot objects had time to be created over the network

--- a/NetworkSerializers/LookAtTargetNetworkSerializable.cs
+++ b/NetworkSerializers/LookAtTargetNetworkSerializable.cs
@@ -299,6 +299,12 @@ namespace LethalBots.NetworkSerializers
                 isSightedIn = false;
             }
 
+            // Check if our look input is disabled.
+            if (lethalBotController.disableLookInput)
+            {
+                return;
+            }
+
             // HACKHACK: Fix the look at code rather than doing this
             if (lethalBotController.isClimbingLadder)
             {

--- a/Patches/GameEnginePatches/HUDManagerPatch.cs
+++ b/Patches/GameEnginePatches/HUDManagerPatch.cs
@@ -9,6 +9,7 @@ using Steamworks.Data;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Reflection.Emit;
 using System.Threading.Tasks;
 using TMPro;
@@ -79,12 +80,96 @@ namespace LethalBots.Patches.GameEnginePatches
         [HarmonyPatch("AddPlayerChatMessageClientRpc")]
         [HarmonyPostfix]
         [HarmonyPriority(Priority.Last)]
+        [Obsolete]
         public static void AddPlayerChatMessageClientRpc_Postfix(HUDManager __instance, string chatMessage, int playerId)
         {
             // Grandpa, why don't we use AddTextToChatOnServer or AddChatMessage?
             // Well you see Timmy, AddTextToChatOnServer is too early and is called for all types of messages
             // and AddChatMessage would only let us hear messages if the local player could hear them!
-            LethalBotManager.Instance.LethalBotsRespondToChatMessage(chatMessage, playerId);
+            if (Plugin.Config.UseOldChatRecevier)
+            {
+                LethalBotManager.Instance.LethalBotsRespondToChatMessage(chatMessage, playerId);
+            }
+        }
+
+        [HarmonyPatch("AddPlayerChatMessageClientRpc")]
+        [HarmonyTranspiler]
+        public static IEnumerable<CodeInstruction> AddPlayerChatMessageClientRpc_Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
+        {
+            var startIndex = -1;
+            var codes = new List<CodeInstruction>(instructions);
+
+            // Target property: GameNetworkManager.Instance.localPlayerController
+            FieldInfo allPlayerScriptsField = AccessTools.Field(typeof(StartOfRound), "allPlayerScripts");
+            FieldInfo playersManagerField = AccessTools.Field(typeof(HUDManager), "playersManager");
+            MethodInfo getGameNetworkManagerInstance = AccessTools.PropertyGetter(typeof(GameNetworkManager), "Instance");
+            FieldInfo localPlayerControllerField = AccessTools.Field(typeof(GameNetworkManager), "localPlayerController");
+            FieldInfo isPlayerDeadField = AccessTools.Field(typeof(PlayerControllerB), "isPlayerDead");
+
+            // Unity Object Equality Method
+            MethodInfo opEqualityMethod = AccessTools.Method(typeof(UnityEngine.Object), "op_Equality");
+
+            // ------------------------------------------------
+            for (var i = 0; i < codes.Count - 8; i++)
+            {
+                // if (playersManager.allPlayerScripts[playerId].isPlayerDead == GameNetworkManager.Instance.localPlayerController.isPlayerDead)
+                if (codes[i].IsLdarg(0)
+                    && codes[i + 1].LoadsField(playersManagerField)
+                    && codes[i + 2].LoadsField(allPlayerScriptsField)
+                    && codes[i + 3].IsLdarg(2)
+                    && codes[i + 4].opcode == OpCodes.Ldelem_Ref
+                    && codes[i + 5].LoadsField(isPlayerDeadField)
+                    && codes[i + 6].Calls(getGameNetworkManagerInstance)
+                    && codes[i + 7].LoadsField(localPlayerControllerField)
+                    && codes[i + 8].LoadsField(isPlayerDeadField))
+                {
+                    startIndex = i;
+                    break;
+                }
+            }
+            if (startIndex > -1)
+            {
+                // Add in our chat command handler to the mix
+                // We make sure to have it run before the base game runs its code
+                List<CodeInstruction> codesToAdd = new List<CodeInstruction>
+                {
+                    new CodeInstruction(OpCodes.Ldarg_1),
+                    new CodeInstruction(OpCodes.Ldarg_2),
+                    new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(HUDManagerPatch), nameof(ChatMessageHandler)))
+                };
+                codes.InsertRange(startIndex, codesToAdd);
+                startIndex = -1;
+            }
+            else
+            {
+                Plugin.LogError($"LethalBots.Patches.GameEnginePatches.AddPlayerChatMessageClientRpc_Transpiler failed to introduce chat command handler!");
+            }
+
+            return codes.AsEnumerable();
+        }
+
+        /// <summary>
+        /// Helper function for use in <see cref="AddPlayerChatMessageClientRpc_Transpiler(IEnumerable{CodeInstruction}, ILGenerator)"/>
+        /// </summary>
+        /// <param name="chatMessage"></param>
+        /// <param name="playerId"></param>
+        private static void ChatMessageHandler(string chatMessage, int playerId)
+        {
+            if (Plugin.Config.UseOldChatRecevier) return;
+
+            // Try-catch here, just in case this errors out so the base game logic still gets to run!
+            try
+            {
+                // Grandpa, why don't we use AddTextToChatOnServer or AddChatMessage?
+                // Well you see Timmy, AddTextToChatOnServer is too early and is called for all types of messages
+                // and AddChatMessage would only let us hear messages if the local player could hear them!
+                //Plugin.LogInfo($"Sending Chat Message {chatMessage} send by player with ID {playerId} to all bots!");
+                LethalBotManager.Instance.LethalBotsRespondToChatMessage(chatMessage, playerId);
+            }
+            catch (Exception e)
+            {
+                Plugin.LogError($"An Error Occurred when trying to relay chat message, {chatMessage}, to bots. Error: {e}");
+            }
         }
 
         /// <summary>

--- a/Patches/GameEnginePatches/StartOfRoundPatch.cs
+++ b/Patches/GameEnginePatches/StartOfRoundPatch.cs
@@ -214,7 +214,7 @@ namespace LethalBots.Patches.GameEnginePatches
         {
             Plugin.LogDebug("Creating and Enabling ship NavMeshSurface object");
             LethalBotManager.Instance.EnsureShipNavMeshBuilt();
-            LethalBotManager.Instance.EnableShipNavMesh("Now in orbit!");
+            LethalBotManager.Instance.EnableShipNavMesh(reason: "Now in orbit!");
         }
 
         [HarmonyPatch("SuckLocalPlayerOutOfShipDoor")]
@@ -351,20 +351,6 @@ namespace LethalBots.Patches.GameEnginePatches
             }
         }
 
-        // Something to think about. Currently, OnShipLandedMiscEvents is called a few seconds after the ship has landed.
-        // This causes the bots to spawn a few seconds after the ship has landed.
-        // This is not a problem, but it would be better to spawn them at the same time as the ship starts its landing.
-        // openingDoorsSequence is the coroutine that is called when the ship is landing.
-        // It is called in the RoundManager class, in the FinishLevelGeneration method.
-        // openingDoorsSequence sets shipDoorsEnabled to true after a few seconds.
-        // This may be the best time to spawn the bots.
-        /*[HarmonyPatch("OnShipLandedMiscEvents")]
-        [HarmonyPostfix]
-        static void OnShipLandedMiscEvents_PostFix()
-        {
-            LethalBotManager.Instance.SpawnLethalBotsAtShip();
-        }*/
-
 
         #region Transpilers
 
@@ -405,129 +391,6 @@ namespace LethalBots.Patches.GameEnginePatches
 
             return codes.AsEnumerable();
         }
-
-        /// <summary>
-        /// Patch for only try to revive irl players not bots
-        /// </summary>
-        /// <param name="instructions"></param>
-        /// <param name="generator"></param>
-        /// <returns></returns>
-        /// TODO: Change this since we want the game to revive the bots!
-        //[HarmonyPatch("ReviveDeadPlayers")]
-        //[HarmonyTranspiler]
-        //public static IEnumerable<CodeInstruction> ReviveDeadPlayers_Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
-        //{
-        //    var startIndex = -1;
-        //    var codes = new List<CodeInstruction>(instructions);
-
-        //    // ----------------------------------------------------------------------
-        //    for (var i = 0; i < codes.Count - 2; i++)
-        //    {
-        //        if (codes[i].ToString().StartsWith("ldarg.0 NULL") //410
-        //            && codes[i + 1].ToString() == "ldfld GameNetcodeStuff.PlayerControllerB[] StartOfRound::allPlayerScripts"
-        //            && codes[i + 2].ToString() == "ldlen NULL")
-        //        {
-        //            startIndex = i;
-        //            break;
-        //        }
-        //    }
-        //    if (startIndex > -1)
-        //    {
-        //        codes[startIndex].opcode = OpCodes.Nop;
-        //        codes[startIndex].operand = null;
-        //        codes[startIndex + 1].opcode = OpCodes.Nop;
-        //        codes[startIndex + 1].operand = null;
-        //        codes[startIndex + 2].opcode = OpCodes.Call;
-        //        codes[startIndex + 2].operand = PatchesUtil.IndexBeginOfInternsMethod;
-        //        startIndex = -1;
-        //    }
-        //    else
-        //    {
-        //        Plugin.LogError($"LethalBot.Patches.GameEnginePatches.StartOfRoundPatch.ReviveDeadPlayers_Transpiler could not use irl number of player in list.");
-        //    }
-
-        //    return codes.AsEnumerable();
-        //}
-
-        //[HarmonyPatch("SyncShipUnlockablesServerRpc")]
-        //[HarmonyTranspiler]
-        //public static IEnumerable<CodeInstruction> SyncShipUnlockablesServerRpc_Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
-        //{
-        //    var startIndex = -1;
-        //    var codes = new List<CodeInstruction>(instructions);
-
-        //    // ----------------------------------------------------------------------
-        //    for (var i = 0; i < codes.Count - 23; i++)
-        //    {
-        //        if (codes[i].ToString().StartsWith("ldarg.0 NULL") // 277
-        //            && codes[i + 1].ToString() == "ldfld GameNetcodeStuff.PlayerControllerB[] StartOfRound::allPlayerScripts"
-        //            && codes[i + 2].ToString() == "ldlen NULL"
-        //            && codes[i + 23].ToString().StartsWith("call void StartOfRound::SyncShipUnlockablesClientRpc")) // 300
-        //        {
-        //            startIndex = i;
-        //            break;
-        //        }
-        //    }
-        //    if (startIndex > -1)
-        //    {
-        //        codes[startIndex].opcode = OpCodes.Nop;
-        //        codes[startIndex].operand = null;
-        //        codes[startIndex + 1].opcode = OpCodes.Nop;
-        //        codes[startIndex + 1].operand = null;
-        //        codes[startIndex + 2].opcode = OpCodes.Call;
-        //        codes[startIndex + 2].operand = PatchesUtil.IndexBeginOfInternsMethod;
-        //        startIndex = -1;
-        //    }
-        //    else
-        //    {
-        //        Plugin.LogError($"LethalBot.Patches.GameEnginePatches.StartOfRoundPatch.SyncShipUnlockablesServerRpc_Transpiler could not use irl number of player in list.");
-        //    }
-
-        //    return codes.AsEnumerable();
-        //}
-
-
-        /// <summary>
-        /// Patch for sync the ship unlockable only for irl players not bots
-        /// </summary>
-        /// <param name="instructions"></param>
-        /// <param name="generator"></param>
-        /// <returns></returns>
-        //[HarmonyPatch("SyncShipUnlockablesClientRpc")]
-        //[HarmonyTranspiler]
-        //public static IEnumerable<CodeInstruction> SyncShipUnlockablesClientRpc_Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
-        //{
-        //    var startIndex = -1;
-        //    var codes = new List<CodeInstruction>(instructions);
-
-        //    // ----------------------------------------------------------------------
-        //    for (var i = 0; i < codes.Count - 2; i++)
-        //    {
-        //        if (codes[i].ToString().StartsWith("ldarg.0 NULL") // 343
-        //            && codes[i + 1].ToString() == "ldfld GameNetcodeStuff.PlayerControllerB[] StartOfRound::allPlayerScripts"
-        //            && codes[i + 2].ToString() == "ldlen NULL")
-        //        {
-        //            startIndex = i;
-        //            break;
-        //        }
-        //    }
-        //    if (startIndex > -1)
-        //    {
-        //        codes[startIndex].opcode = OpCodes.Nop;
-        //        codes[startIndex].operand = null;
-        //        codes[startIndex + 1].opcode = OpCodes.Nop;
-        //        codes[startIndex + 1].operand = null;
-        //        codes[startIndex + 2].opcode = OpCodes.Call;
-        //        codes[startIndex + 2].operand = PatchesUtil.IndexBeginOfInternsMethod;
-        //        startIndex = -1;
-        //    }
-        //    else
-        //    {
-        //        Plugin.LogError($"LethalBot.Patches.GameEnginePatches.StartOfRoundPatch.SyncShipUnlockablesClientRpc_Transpiler could not use irl number of player in list.");
-        //    }
-
-        //    return codes.AsEnumerable();
-        //}
 
         /// <summary>
         /// Patch for bypassing the annoying debug logs.
@@ -717,111 +580,6 @@ namespace LethalBots.Patches.GameEnginePatches
 
             return codes.AsEnumerable();
         }
-
-        /// <summary>
-        /// Check only real players not bots
-        /// </summary>
-        /// <param name="__instance"></param>
-        /// <param name="clientId"></param>
-        /// <param name="instructions"></param>
-        /// <param name="generator"></param>
-        /// <returns></returns>
-        //[HarmonyPatch("ResetShipFurniture")]
-        //[HarmonyTranspiler]
-        //public static IEnumerable<CodeInstruction> ResetShipFurniture_Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
-        //{
-        //    var startIndex = -1;
-        //    List<CodeInstruction> codes = new List<CodeInstruction>(instructions);
-
-        //    // ----------------------------------------------------------------------
-        //    for (var i = 0; i < codes.Count - 3; i++)
-        //    {
-        //        if (codes[i].ToString().StartsWith("ldarg.0 NULL") //176
-        //            && codes[i + 1].ToString() == "ldfld GameNetcodeStuff.PlayerControllerB[] StartOfRound::allPlayerScripts"
-        //            && codes[i + 2].ToString() == "ldlen NULL")
-        //        {
-        //            startIndex = i;
-        //            break;
-        //        }
-        //    }
-        //    if (startIndex > -1)
-        //    {
-        //        codes[startIndex].opcode = OpCodes.Nop;
-        //        codes[startIndex].operand = null;
-        //        codes[startIndex + 1].opcode = OpCodes.Nop;
-        //        codes[startIndex + 1].operand = null;
-        //        codes[startIndex + 2].opcode = OpCodes.Call;
-        //        codes[startIndex + 2].operand = PatchesUtil.IndexBeginOfInternsMethod;
-        //        startIndex = -1;
-        //    }
-        //    else
-        //    {
-        //        Plugin.LogError($"LethalBot.Patches.NpcPatches.PlayerControllerBPatch.ResetShipFurniture_Transpiler could not use irl number of player in list.");
-        //    }
-
-        //    return codes.AsEnumerable();
-        //}
-
-        //[HarmonyPatch("OnClientConnect")]
-        //[HarmonyTranspiler]
-        //public static IEnumerable<CodeInstruction> OnClientConnect_Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
-        //{
-        //    var startIndex = -1;
-        //    var codes = new List<CodeInstruction>(instructions);
-
-        //    if (DebugConst.TEST_MORE_THAN_X_PLAYER_BYPASS)
-        //    {
-        //        // ----------------------------------------------------------------------
-        //        for (var i = 0; i < codes.Count - 11; i++)
-        //        {
-        //            if (codes[i].ToString().StartsWith("ldc.i4.1 NULL") // 24
-        //                && codes[i + 5].ToString().StartsWith("callvirt virtual bool System.Collections.Generic.List<int>::Contains") // 29
-        //                && codes[i + 11].ToString() == "ldc.i4.1 NULL")// 35
-        //            {
-        //                startIndex = i;
-        //                break;
-        //            }
-        //        }
-        //        if (startIndex > -1)
-        //        {
-        //            codes[startIndex].opcode = OpCodes.Ldc_I4_3;
-        //            codes[startIndex].operand = null;
-        //            startIndex = -1;
-        //        }
-        //        else
-        //        {
-        //            Plugin.LogError($"LethalBot.Patches.GameEnginePatches.StartOfRoundPatch.OnClientConnect_Transpiler could not test with making the 2nd player the nth");
-        //        }
-        //    }
-
-        //    // ----------------------------------------------------------------------
-        //    for (var i = 0; i < codes.Count - 2; i++)
-        //    {
-        //        if (codes[i].ToString() == "ldarg.0 NULL"
-        //            && codes[i + 1].ToString() == "ldfld UnityEngine.GameObject[] StartOfRound::allPlayerObjects"
-        //            && codes[i + 2].ToString() == "ldlen NULL")
-        //        {
-        //            startIndex = i;
-        //            break;
-        //        }
-        //    }
-        //    if (startIndex > -1)
-        //    {
-        //        codes[startIndex].opcode = OpCodes.Nop;
-        //        codes[startIndex].operand = null;
-        //        codes[startIndex + 1].opcode = OpCodes.Nop;
-        //        codes[startIndex + 1].operand = null;
-        //        codes[startIndex + 2].opcode = OpCodes.Call;
-        //        codes[startIndex + 2].operand = PatchesUtil.IndexBeginOfInternsMethod;
-        //        startIndex = -1;
-        //    }
-        //    else
-        //    {
-        //        Plugin.LogError($"LethalBot.Patches.GameEnginePatches.StartOfRoundPatch.OnClientConnect_Transpiler could not limit init of list2");
-        //    }
-
-        //    return codes.AsEnumerable();
-        //}
 
         #endregion
 

--- a/Thunderstore/CHANGELOG.md
+++ b/Thunderstore/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 10.1.0 2026-6-27
+Hey everyone, just have some minor bug fixes. Anyhow, lets get on with em.<br/>
+Change Log:
+- Moved NavMesh area costs for bots into its own function: LethalBotAI.SetAreaCostsForBot
+- Fixed a bug that caused the bots to reset their area costs back to default. No more bots dive bombing into the water on March.
+- Added randomization to AI update intervals to be consistent with how the base game does it.
+- Improved handling of external forces on bots
+- Changed chat command handling to use a Harmony transpiler rather than a postfix. This fixes the bots sometimes sending messages twice.
+- Added `UseOldChatRecevier` config for chat command fallback
+
 ## 10.0.0 2026-6-24
 Welp, this took longer than planned. It didn't help that I kept getting sidetracked in the process. Anyhow, I finally took the time to improve the follow state as requested in #68. Its completely configurable and client sided, this means that each player gets to decide how bots should follow them. I also made a TON of backend changes and bug fixes, so lets get onto it!
 

--- a/Thunderstore/CHANGELOG.md
+++ b/Thunderstore/CHANGELOG.md
@@ -9,6 +9,7 @@ Change Log:
 - Improved handling of external forces on bots
 - Changed chat command handling to use a Harmony transpiler rather than a postfix. This fixes the bots sometimes sending messages twice.
 - Added `UseOldChatRecevier` config for chat command fallback
+- Actually fixed bots being able to look around when their look input is disabled
 
 ## 10.0.0 2026-6-24
 Welp, this took longer than planned. It didn't help that I kept getting sidetracked in the process. Anyhow, I finally took the time to improve the follow state as requested in #68. Its completely configurable and client sided, this means that each player gets to decide how bots should follow them. I also made a TON of backend changes and bug fixes, so lets get onto it!


### PR DESCRIPTION
Hey everyone, just have some minor bug fixes. Anyhow, lets get on with em.<br/>
Change Log:
- Moved NavMesh area costs for bots into its own function: LethalBotAI.SetAreaCostsForBot
- Fixed a bug that caused the bots to reset their area costs back to default. No more bots dive bombing into the water on March.
- Added randomization to AI update intervals to be consistent with how the base game does it.
- Improved handling of external forces on bots
- Changed chat command handling to use a Harmony transpiler rather than a postfix. This fixes the bots sometimes sending messages twice.
- Added `UseOldChatRecevier` config for chat command fallback
- Actually fixed bots being able to look around when their look input is disabled