### PR TITLE
12.0.0 Quota System Improvements

### DIFF
--- a/AI/AIState.cs
+++ b/AI/AIState.cs
@@ -303,11 +303,6 @@ namespace LethalBots.AI
                 if (state.IsBotBeingAddressed(playerWhoSentMessage, out var lethalBotController, isVoice: isVoice, allowNonOwner: true))
                 {
                     // Yay, we found a vaild bot, have the bot follow the player who sent the message!
-                    if (lethalBotAI.IsSpawningAnimationRunning())
-                    {
-                        return true;
-                    }
-
                     EnumAIStates currentBotState = state.GetAIState();
                     if (lethalBotAI.OwnerClientId != playerWhoSentMessage.actualClientId
                         || !lethalBotAI.IsFollowingLocalPlayer())
@@ -405,6 +400,39 @@ namespace LethalBots.AI
                     });
 
                     lethalBotAI.State = new HoldPositionState(state, lethalBotAI.NpcController.Npc.transform.position);
+                }
+                return true;
+            }));
+
+            // A player asked us to drop our held item
+            ChatCommandsManager.RegisterGlobalCommand(new ChatCommand(Const.DROP_HELD_ITEM_COMMANDS, (state, lethalBotAI, playerWhoSentMessage, message, isVoice) =>
+            {
+                if (state.IsBotBeingAddressed(playerWhoSentMessage, out var lethalBotController, isVoice: isVoice, allowNonOwner: true))
+                {
+                    // Yay, we found a vaild bot, have the bot drop its currently held item.
+                    if (!lethalBotAI.AreHandsFree())
+                    {
+                        // Bot drop item
+                        lethalBotController.DiscardHeldObject();
+                    }
+                    // If we still have stuff in our inventory,
+                    // we should swap to it in case the player wants us to drop it!
+                    else if (lethalBotAI.HasSomethingInInventory())
+                    {
+                        GrabbableObject? itemOnlySlot = lethalBotController.ItemOnlySlot;
+                        if (itemOnlySlot != null)
+                        {
+                            lethalBotAI.SwitchItemSlotsAndSync(Const.RESERVED_EQUIPMENT_SLOT);
+                        }
+                        GrabbableObject?[] itemSlots = lethalBotController.ItemSlots;
+                        for (int i = 0; i < itemSlots.Length; i++)
+                        {
+                            if (itemSlots[i] != null)
+                            {
+                                lethalBotAI.SwitchItemSlotsAndSync(i);
+                            }
+                        }
+                    }
                 }
                 return true;
             }));

--- a/AI/AIStates/FightEnemyState.cs
+++ b/AI/AIStates/FightEnemyState.cs
@@ -385,15 +385,9 @@ namespace LethalBots.AI.AIStates
 
                 // Check if we are still close enough!
                 Vector3 targetPos = EnemyCollider != null ? EnemyCollider.bounds.center : this.CurrentEnemy.eye.position;
-                if (!CanHitEnemyWithHeldItem(heldItem, targetPos))
-                {
-                    canHitTarget = false;
-                    yield return null;
-                    continue;
-                }
+                canHitTarget = CanHitEnemyWithHeldItem(heldItem, targetPos);
 
-                // We have a shot!
-                canHitTarget = true;
+                // Respect attack cooldown!
                 if (attackCooldownTimer.HasStarted() && !attackCooldownTimer.Elapsed())
                 {
                     yield return null;
@@ -402,7 +396,7 @@ namespace LethalBots.AI.AIStates
 
                 // ATTACK!
                 bool skipCooldown = false;
-                yield return weaponInfo.AttackWithWeapon(npcController.Npc, heldItem, CurrentEnemy, EnemyCollider, r => skipCooldown = r);
+                yield return weaponInfo.AttackWithWeapon(npcController.Npc, heldItem, CurrentEnemy, EnemyCollider, canHitTarget, r => skipCooldown = r);
 
                 // Did the weapon do its own cooldown, skip the default one then
                 if (skipCooldown) continue;

--- a/AI/AIStates/RescueAndReviveState.cs
+++ b/AI/AIStates/RescueAndReviveState.cs
@@ -20,6 +20,7 @@ using System.Runtime.CompilerServices;
 using UnityEngine;
 using UnityEngine.InputSystem.HID;
 using UsualScrap.Behaviors;
+using UsualScrap.Patches;
 
 namespace LethalBots.AI.AIStates
 {
@@ -441,15 +442,59 @@ namespace LethalBots.AI.AIStates
         {
             if (defibUnit is DefibrillatorScript defibrillator)
             {
-                FieldInfo permaDeathRuleField = AccessTools.Field(typeof(DefibrillatorScript), "PermaDeathRule");
-                if ((bool)permaDeathRuleField.GetValue(defibrillator) == false)
+                // Do we need to do the PermaDeath checks
+                if (!defibrillator.PermaDeathRule)
                 {
                     return true;
                 }
+
+                // Welp, let go through the list
                 DeadBodyInfo deadBodyInfo = playerToRevive.deadBody;
                 if (deadBodyInfo != null)
                 {
-                    return deadBodyInfo.causeOfDeath != CauseOfDeath.Snipping && !deadBodyInfo.detachedHead;
+                    // Kinda hard to defib a player with no head
+                    if (deadBodyInfo.detachedHead || deadBodyInfo.detachedHeadObject != null)
+                    {
+                        Plugin.LogDebug("US - This corpse has no head!");
+                        return false;
+                    }
+
+                    // Make sure its not an invalid death type!
+                    if (Deathtracker.DeathAnimations.TryGetValue(deadBodyInfo.playerObjectId, out var value))
+                    {
+                        bool flag;
+                        switch (value)
+                        {
+                            case -1:
+                            case 1:
+                            case 2:
+                            case 6:
+                            case 7:
+                            case 8:
+                            case 9:
+                                flag = true;
+                                break;
+                            default:
+                                flag = false;
+                                break;
+                        }
+
+                        if (flag)
+                        {
+                            Plugin.LogDebug("US - This corpse can't be saved. What a mess.");
+                            return false;
+                        }
+                    }
+
+                    // Check for contaminated dead bodies
+                    if (Deathtracker.BurstCorpses.Contains(deadBodyInfo.playerObjectId) 
+                        || Deathtracker.SpiderWebbedBodies.Contains(deadBodyInfo.playerObjectId))
+                    {
+                        Plugin.LogDebug("US - This corpse is infected. Nasty.");
+                        return false;
+                    }
+
+                    return true;
                 }
             }
             return false;

--- a/AI/LethalBotAI.cs
+++ b/AI/LethalBotAI.cs
@@ -4911,7 +4911,7 @@ namespace LethalBots.AI
                 // Get grabbable object infos
                 // NOTE: This also functions as a null check!
                 GrabbableObject? grabbableObject = LethalBotManager.grabbableObjectsInMap[i];
-                if (grabbableObject is not RagdollGrabbableObject deadBody)
+                if (grabbableObject == null || grabbableObject is not RagdollGrabbableObject deadBody)
                 {
                     //Plugin.LogInfo("Body is null!");
                     continue;

--- a/Configs/Config.cs
+++ b/Configs/Config.cs
@@ -25,6 +25,7 @@ namespace LethalBots.Configs
     {
         // Bot settings
         [SyncedEntryField] public SyncedEntry<int> PlayerQuota;
+        [SyncedEntryField] public SyncedEntry<EnumQuotaType> QuotaType;
         [SyncedEntryField] public SyncedEntry<bool> BotsAutoJoin;
         [SyncedEntryField] public SyncedEntry<bool> AllowBotsInOrbit;
         [SyncedEntryField] public SyncedEntry<bool> ShowBillboardStateIndicator;
@@ -90,8 +91,13 @@ namespace LethalBots.Configs
             PlayerQuota = cfg.BindSyncedEntry(ConfigConst.ConfigSectionMain,
                                            "Player Quota",
                                            defaultValue: ConfigConst.DEFAULT_MAX_BOTS_AVAILABLE,
-                                           new ConfigDescription("How many players should Lethal Bots try to keep in the lobby? \n If there are less players than the set value, bots will automatically join. \n If there are more players than the set value, bots will automatically be kicked. \n This respects max lobby size. \n Be aware of possible performance problems when more than ~16 bots spawned",
+                                           new ConfigDescription("How many players should Lethal Bots try to keep in the lobby? \n This respects max lobby size. \n Be aware of possible performance problems when more than ~16 bots spawned",
                                                                  new AcceptableValueRange<int>(ConfigConst.MIN_BOTS_AVAILABLE, ConfigConst.MAX_BOTS_AVAILABLE)));
+
+            QuotaType = cfg.BindSyncedEntry(ConfigConst.ConfigSectionMain,
+                                            "Quota Type",
+                                            defaultVal: EnumQuotaType.Normal,
+                                            "How should the Player Quota be used? \n NORMAL: Maintains the total number of players (humans + bots) at the configured quota. \n FILL: Maintains exactly the configured number of bots, regardless of how many human players are connected.");
 
             BotsAutoJoin = cfg.BindSyncedEntry(ConfigConst.ConfigSectionMain,
                                             "Bots Auto Join",

--- a/Constants/Const.cs
+++ b/Constants/Const.cs
@@ -162,6 +162,7 @@ namespace LethalBots.Constants
         public static readonly string[] LEAD_THE_WAY_COMMANDS = { "lead the way", "search for scrap" };
         public static readonly string[] CHANGE_SUIT_COMMANDS = { "change suit", "change your suit", "change your outfit" };
         public static readonly string[] WAIT_HERE_COMMANDS = { "wait here", "stay here" };
+        public static readonly string[] DROP_HELD_ITEM_COMMANDS = { "drop your held item", "drop it" };
 
         // Mission Control State Consts
         public const string ROUTE_MOON_COMMAND = "route"; // keeps "route" as the only trigger word to avoid accidental triggering

--- a/Enums/EnumQuotaType.cs
+++ b/Enums/EnumQuotaType.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace LethalBots.Enums
+{
+    [Serializable]
+    public enum EnumQuotaType
+    {
+        Normal,
+        Fill
+    }
+}

--- a/LethalBot.csproj
+++ b/LethalBot.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>LethalBots</AssemblyName>
     <Product>LethalBots</Product>
     <!-- Change to whatever version you're currently on. This will be used by tcli when building our Thunderstore package. -->
-    <Version>11.0.0</Version>
+    <Version>12.0.0</Version>
   </PropertyGroup>
 
   <!-- Project Properties -->
@@ -92,7 +92,7 @@
     <PackageReference Include="BepInEx.AssemblyPublicizer.MSBuild" Version="0.4.3" PrivateAssets="all" ExcludeAssets="runtime" />
     <PackageReference Include="BepInEx.Core" Version="5.*" />
     <PackageReference Include="BepInEx.PluginInfoProps" Version="2.1.0" PrivateAssets="all" />
-    <PackageReference Include="etherealemil-UsualScrap" Version="2.0.4" Publicize="true" />
+    <PackageReference Include="etherealemil-UsualScrap" Version="2.0.5" Publicize="true" />
     <PackageReference Include="Evaisa.LethalLib" Version="1.2.0" />
     <PackageReference Include="Lost.Compat.NullabilityAttributes" Version="0.0.4" PrivateAssets="all" />
     <PackageReference Include="MillieTheSilly-SuperEclipse" Version="0.1.0" />

--- a/Managers/LethalBotManager.cs
+++ b/Managers/LethalBotManager.cs
@@ -1117,20 +1117,31 @@ namespace LethalBots.Managers
         {
             // Only run some of this on the server
             StartOfRound instanceSOR = StartOfRound.Instance;
-            if (IsServer && !isSpawningBots.Value)
+            if (IsServer 
+                && !isSpawningBots.Value 
+                && !NetworkManager.ShutdownInProgress)
             {
                 if (sendPlayerCountUpdate.Value)
                 {
                     // Check and update the amount of dead and living players
+                    int connectedPlayerCount = 0;
                     int livingPlayerCount = 0;
-                    foreach (PlayerControllerB playerControllerB in instanceSOR.allPlayerScripts)
+                    for (int i = 0; i < instanceSOR.allPlayerScripts.Length; i++)
                     {
-                        if (playerControllerB.isPlayerControlled && !playerControllerB.isPlayerDead)
+                        PlayerControllerB playerControllerB = instanceSOR.allPlayerScripts[i];
+                        if (playerControllerB.isPlayerControlled || playerControllerB.isPlayerDead)
                         {
-                            livingPlayerCount++;
+                            connectedPlayerCount++;
+                            if (!playerControllerB.isPlayerDead)
+                            {
+                                livingPlayerCount++;
+                            }
                         }
                     }
-                    SendNewPlayerCountServerRpc(instanceSOR.connectedPlayersAmount, livingPlayerCount, GameNetworkManager.Instance.connectedPlayers);
+
+                    // Send new player count.
+                    // NOTE: We subtract one from the connectedPlayerCount as connectedPlayersAmount is not supposed to incude the host player
+                    SendNewPlayerCountServerRpc(Mathf.Max(connectedPlayerCount - 1, 0), livingPlayerCount, GameNetworkManager.Instance.connectedPlayers);
                 }
                 // If we are in orbit, mantain the bot quota.
                 // NOTE: This only works if bots are allowed in orbit
@@ -1149,7 +1160,7 @@ namespace LethalBots.Managers
                         int desiredQuotaAmount = Mathf.Min(Plugin.Config.PlayerQuota.Value, instanceSOR.allPlayerScripts.Length); // Number of players to keep on the server
 
                         // Check if there are too MANY players
-                        if (connectedPlayersAmount > desiredQuotaAmount && connectedBotAmount > 0)
+                        if (AreTooManyBots(connectedPlayersAmount, connectedBotAmount, desiredQuotaAmount) && connectedBotAmount > 0)
                         {
                             // Go through every spawned bot
                             for (int i = 0; i < AllLethalBotAIs.Length; i++) 
@@ -1172,7 +1183,7 @@ namespace LethalBots.Managers
                             }
                         }
                         // Check if there are too FEW players
-                        else if (connectedPlayersAmount < desiredQuotaAmount)
+                        else if (AreTooFewBots(connectedPlayersAmount, connectedBotAmount, desiredQuotaAmount))
                         {
                             // Make sure the NavMesh is built
                             EnsureShipNavMeshBuilt();
@@ -1197,6 +1208,11 @@ namespace LethalBots.Managers
                             }
                         }
                     }
+                }
+                // If we are not in orbit, keep reseting the quota timer
+                else
+                {
+                    maintainQuotaTimer.Start(1.0f); // Check every second
                 }
             }
 
@@ -2202,7 +2218,7 @@ namespace LethalBots.Managers
             StartOfRound.Instance.ClientPlayerList[lethalBotController.actualClientId] = (int)lethalBotController.playerClientId;
 
             // Send player count update
-            if (IsServer || IsHost)
+            if (IsServer)
             {
                 // Make sure we sync the bot's level
                 HUDManager.Instance.SyncPlayerLevelServerRpc((int)lethalBotController.playerClientId, lethalBotAI.LethalBotIdentity.Level, true);
@@ -2675,6 +2691,38 @@ namespace LethalBots.Managers
             }
         }
 
+        /// <summary>
+        /// Checks if the given number of <paramref name="connectedPlayersAmount"/> and <paramref name="connectedBotAmount"/> are greater than the given <paramref name="desiredQuotaAmount"/>
+        /// </summary>
+        /// <returns></returns>
+        private bool AreTooFewBots(int connectedPlayersAmount, int connectedBotAmount, int desiredQuotaAmount)
+        {
+            switch (Plugin.Config.QuotaType.Value)
+            {
+                case EnumQuotaType.Fill:
+                    return connectedBotAmount < desiredQuotaAmount;
+                case EnumQuotaType.Normal:
+                default:
+                    return connectedPlayersAmount < desiredQuotaAmount;
+            }
+        }
+
+        /// <summary>
+        /// Checks if the given number of <paramref name="connectedPlayersAmount"/> and <paramref name="connectedBotAmount"/> are less than the given <paramref name="desiredQuotaAmount"/>
+        /// </summary>
+        /// <returns></returns>
+        private bool AreTooManyBots(int connectedPlayersAmount, int connectedBotAmount, int desiredQuotaAmount)
+        {
+            switch (Plugin.Config.QuotaType.Value)
+            {
+                case EnumQuotaType.Fill:
+                    return connectedBotAmount > desiredQuotaAmount;
+                case EnumQuotaType.Normal:
+                default:
+                    return connectedPlayersAmount > desiredQuotaAmount;
+            }
+        }
+
         #endregion
 
         #region Signal Translator, Chat Messages, and Voice Chat Handling
@@ -2688,8 +2736,9 @@ namespace LethalBots.Managers
             // Make the message case insensitive!
             message = message.Trim().ToLower();
 
-            foreach (LethalBotAI lethalBotAI in AllLethalBotAIs)
+            for (int i = 0; i < AllLethalBotAIs.Length; i++)
             {
+                LethalBotAI lethalBotAI = AllLethalBotAIs[i];
                 if (lethalBotAI == null
                     || !lethalBotAI.NpcController.Npc.isPlayerControlled
                     || lethalBotAI.State == null)
@@ -2971,8 +3020,9 @@ namespace LethalBots.Managers
                 }
             }
 
-            foreach (LethalBotAI lethalBotAI in AllLethalBotAIs)
+            for (int i = 0; i < AllLethalBotAIs.Length; i++)
             {
+                LethalBotAI lethalBotAI = AllLethalBotAIs[i];
                 PlayerControllerB? botController = lethalBotAI?.NpcController?.Npc;
                 if (lethalBotAI == null
                     || botController == null
@@ -3024,8 +3074,9 @@ namespace LethalBots.Managers
             // Make the message case insensitive!
             message = message.Trim().ToLower();
 
-            foreach (LethalBotAI lethalBotAI in AllLethalBotAIs)
+            for (int i = 0; i < AllLethalBotAIs.Length; i++)
             {
+                LethalBotAI lethalBotAI = AllLethalBotAIs[i];
                 PlayerControllerB? botController = lethalBotAI?.NpcController?.Npc;
                 if (lethalBotAI == null 
                     || botController == null
@@ -3836,6 +3887,13 @@ namespace LethalBots.Managers
                 return;
             }
 
+            // Don't do this if the lobby is closing
+            if (NetworkManager.ShutdownInProgress)
+            {
+                Plugin.LogInfo($"Skipping player count update. Server is shutting down.");
+                return;
+            }
+
             StartOfRound instanceSOR = StartOfRound.Instance;
             int oldPlayerCount = instanceSOR.connectedPlayersAmount;
             int oldLivingPlayerCount = instanceSOR.livingPlayers;
@@ -3850,8 +3908,10 @@ namespace LethalBots.Managers
             Plugin.LogInfo($"[Server] Old Num of Living Players {oldLivingPlayerCount} -> {instanceSOR.livingPlayers}");
             Plugin.LogInfo($"[Server] Real Players Count: {AllRealPlayersCount}");
 
+            // Reset Quota Timer
+            maintainQuotaTimer.Start(1.0f); // Check every second
+
             // Send the updated values to all clients
-            sendPlayerCountUpdate.Value = false;
             SendNewPlayerCountClientRpc(numConnectedPlayers, numLivingPlayers, numRealPlayers);
         }
 
@@ -3866,8 +3926,18 @@ namespace LethalBots.Managers
         private void SendNewPlayerCountClientRpc(int numConnectedPlayers, int numLivingPlayers, int numRealPlayers)
         {
             // The host already updated these values, no need to do it again
-            if (IsServer || IsHost)
+            if (IsServer)
             {
+                // Reset Quota Timer
+                maintainQuotaTimer.Start(1.0f); // Check every second
+                sendPlayerCountUpdate.Value = false; // Mark it updated for other clients
+                return;
+            }
+
+            // Don't do this if the lobby is closing
+            if (NetworkManager.ShutdownInProgress)
+            {
+                Plugin.LogInfo($"Skipping player count update. Server is shutting down.");
                 return;
             }
 
@@ -5138,7 +5208,10 @@ namespace LethalBots.Managers
 
             // Setup our navmesh prefab
             GameObject? enviormentObject = GameObject.Find("Environment");
-            shipNavMeshInstance ??= Object.Instantiate(GetShipNavPrefab());
+            if (shipNavMeshInstance == null)
+            {
+                shipNavMeshInstance = Object.Instantiate(GetShipNavPrefab());
+            }
             shipNavMeshInstance.SetActive(true);
             shipNavMeshInstance.transform.SetParent(StartOfRound.Instance.elevatorTransform, true);
 

--- a/Managers/SaveManager.cs
+++ b/Managers/SaveManager.cs
@@ -86,6 +86,16 @@ namespace LethalBots.Managers
                             identitySaveFile.Status = (int)EnumStatusIdentity.Available; // Ensure status is set to Available, as it might be saved as ToSpawn
                         }
                     }
+                    else
+                    {
+                        foreach (IdentitySaveFile identitySaveFile in Save.IdentitiesSaveFiles)
+                        {
+                            if (identitySaveFile.Status == (int)EnumStatusIdentity.Spawned)
+                            {
+                                identitySaveFile.Status = (int)EnumStatusIdentity.ToSpawn; // Ensure status is set to ToSpawn, as it might be saved as Spawned
+                            }
+                        }
+                    }
                 }
                 else
                 {

--- a/Patches/ModPatches/UsualScrap/UsualScrapWeaponsPatch.cs
+++ b/Patches/ModPatches/UsualScrap/UsualScrapWeaponsPatch.cs
@@ -2,6 +2,7 @@
 using LethalBots.Managers;
 using LethalBots.Utils.Helpers;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Text;
 using UnityEngine;
@@ -17,6 +18,8 @@ namespace LethalBots.Patches.ModPatches.UsualScrap
             itemsManager.RegisterNewWeapon<CrowbarScript>(new CrowbarInfo());
             itemsManager.RegisterNewWeapon<SizableScissorsScript>(new SizableScissorsInfo());
             itemsManager.RegisterNewWeapon<CandyDispenserScript>(new CandyDispenserInfo());
+            itemsManager.RegisterNewWeapon<SledgehammerScript>(new SledgehammerInfo());
+            itemsManager.RegisterNewWeapon<RedoneBlowtorch>(new RedoneBlowtorchInfo());
         }
 
         private class CrowbarInfo : WeaponInfo
@@ -96,6 +99,145 @@ namespace LethalBots.Patches.ModPatches.UsualScrap
                 {
                     // If we somehow were not given the candy dispenser object, just return the default
                     base.GetWeaponAttackInfo(weapon, lethalBotController, out ray, out maxFOV, out radius, out maxRange, out hitMask);
+                }
+            }
+        }
+
+        private class SledgehammerInfo : WeaponInfo
+        {
+            public override float GetAttackRangeForWeapon(GrabbableObject weapon)
+            {
+                return 2f; // Same as the shovel
+            }
+
+            public override void GetWeaponAttackInfo(GrabbableObject weapon, PlayerControllerB lethalBotController, out Ray ray, out float maxFOV, out float radius, out float maxRange, out LayerMask hitMask)
+            {
+                // Provide the info about how to use the blowtorch
+                if (weapon is SledgehammerScript sledgehammer)
+                {
+                    // This is how the mod does it.
+                    ray = new Ray(lethalBotController.gameplayCamera.transform.position + lethalBotController.gameplayCamera.transform.right * -0.35f, lethalBotController.gameplayCamera.transform.forward);
+                    maxFOV = 75f;
+                    radius = 0.8f;
+                    maxRange = 1.5f;
+                    hitMask = sledgehammer.meleeWeaponMask;
+                }
+                else
+                {
+                    // If we somehow were not given the candy dispenser object, just return the default
+                    base.GetWeaponAttackInfo(weapon, lethalBotController, out ray, out maxFOV, out radius, out maxRange, out hitMask);
+                }
+            }
+        }
+
+        private class RedoneBlowtorchInfo : WeaponInfo
+        {
+            private static readonly LayerMask attackMask = LayerMask.GetMask("Enemies");
+
+            public RedoneBlowtorchInfo()
+            {
+                enemyColliders = new RaycastHit[10];
+            }
+
+            public override bool IsRanged(GrabbableObject weapon)
+            {
+                return true;
+            }
+
+            public override float GetAttackRangeForWeapon(GrabbableObject weapon)
+            {
+                return 4f; // Based on the range found in the source code
+            }
+
+            public override float GetWeaponAttackInterval(GrabbableObject weapon)
+            {
+                return 0.1f; // Let us update a bit faster
+            }
+
+            public override void GetWeaponAttackInfo(GrabbableObject weapon, PlayerControllerB lethalBotController, out Ray ray, out float maxFOV, out float radius, out float maxRange, out LayerMask hitMask)
+            {
+                // Provide the info about how to use the blowtorch
+                if (weapon is RedoneBlowtorch blowtorch)
+                {
+                    // This is how the mod does it.
+                    ray = new Ray(lethalBotController.gameplayCamera.transform.position + lethalBotController.gameplayCamera.transform.forward * 0.5f, lethalBotController.gameplayCamera.transform.forward);
+                    maxFOV = 30f;
+                    radius = 0.35f;
+                    maxRange = 3.5f;
+                    hitMask = attackMask;
+                }
+                else
+                {
+                    // If we somehow were not given the candy dispenser object, just return the default
+                    base.GetWeaponAttackInfo(weapon, lethalBotController, out ray, out maxFOV, out radius, out maxRange, out hitMask);
+                }
+            }
+
+            public override bool CanHitWithWeapon(PlayerControllerB lethalBotController, EnemyAI currentEnemy, Collider? enemyCollider, Ray ray, float radius, float maxRange, LayerMask hitMask)
+            {
+                // Check if we hit the target based on the weapon's hitmask!
+                enemyColliders ??= new RaycastHit[10];
+                int hitCount = Physics.SphereCastNonAlloc(ray, radius, enemyColliders, maxRange, hitMask, QueryTriggerInteraction.Collide);
+                EnemyAICollisionDetect? closestEnemy = null;
+                float closestDistance = float.MaxValue;
+                for (int i = 0; i < hitCount; i++)
+                {
+                    // Do the same logic the mod does
+                    RaycastHit raycastHit = enemyColliders[i];
+                    EnemyAICollisionDetect detect = raycastHit.collider.GetComponentInParent<EnemyAICollisionDetect>();
+                    if (detect != null && detect.TryGetComponent<IHittable>(out _) && (!detect.onlyCollideWhenGrounded || detect.alwaysAllowHitting))
+                    {
+                        if (raycastHit.distance < closestDistance)
+                        {
+                            closestDistance = raycastHit.distance;
+                            closestEnemy = detect;
+                        }
+                    }
+                }
+
+                // Don't need to check collider here, since we grab the enemy itself
+                return closestEnemy != null && closestEnemy.mainScript == currentEnemy;
+            }
+
+            public override IEnumerator AttackWithWeapon(PlayerControllerB lethalBotController, GrabbableObject weapon, EnemyAI currentEnemy, Collider? enemyCollider, bool canHitTarget, Action<bool> setSkipCooldown)
+            {
+                // Here is a good example of the canHitTarget being useful. I can tell the bot to stop firing their weapon
+                // without needing to add some complex buttons system for the bot.
+                if (weapon is RedoneBlowtorch blowtorch)
+                {
+                    // Don't let it overheat!
+                    if (!canHitTarget || blowtorch.currentHeat >= blowtorch.heatThreshold - blowtorch.heatGainRate)
+                    {
+                        // Release our attack key
+                        if (blowtorch.isHoldingButton)
+                        {
+                            weapon.UseItemOnClient(false);
+                        }
+                        yield return null;
+                        yield break;
+                    }
+                    // Attack!
+                    else if (blowtorch.currentHeat < blowtorch.heatThreshold / 2f)
+                    {
+                        // Press and hold!
+                        if (!blowtorch.isHoldingButton)
+                        {
+                            weapon.UseItemOnClient(true);
+                        }
+                    }
+                }
+
+            }
+
+            public override void UseHeldWeapon(PlayerControllerB lethalBotController, GrabbableObject weapon, ref bool canUseLethalPhones)
+            {
+                if (weapon is RedoneBlowtorch blowtorch)
+                {
+                    // Turn off the blowtorch, we are not using it anymore
+                    if (blowtorch.isHoldingButton)
+                    {
+                        weapon.UseItemOnClient(false);
+                    }
                 }
             }
         }

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Also, the bot only checks for the keywords anywhere in the message, for example,
 </br>**follow me** - The bot will move to follow you
 </br>**lead the way** - The bot will go to search for scrap on its own
 </br>**change suit** - The bot will change its suit to the suit you are wearing
+</br>**drop your held item** - The bot will drop its held item. If the bot is not holding anything, it will swap to the next item in its inventory.
 </br>Please note that you must be in chat range for the bot to hear you. If you are too far away, the bot will not respond to your command.
 If both you and the bot have a walkie-talkie, you can use the command in the chat and the bot will respond to it.
 </br>Please note that these are also voice commands, but they require you to only say the word unlike how they work as said in the chat.

--- a/Thunderstore/CHANGELOG.md
+++ b/Thunderstore/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 12.0.0 2026-7-18
+Back again with a not so minor update. I made some requested changes to the Quota system. I also updated the bot's Usual Scrap support as well! Oh and fixed some bugs, as always.
+- Added QuotaType config to allow users to change how the bot quota system decides how many bots to keep in the lobby
+- Introduced "drop held item" chat command for bots
+- Added support for Sledgehammer and Blowtorch from Usual Scrap
+- Updated Usual Scrap revive logic to be up to date with its new changes
+- Fixed some issues with the player count being desynced. (This also happend if you disconnected and opened another save file.
+- Fixed some potentially null ref errors
+- Improved the Bot Weapon API. THIS INCLUDES BREAKING CHANGES. WeaponInfo.AttackWithWeapon has a new parameter and will always be called, even if the bot doesn't believe it can hit its target.
+
 ## 11.0.0 2026-7-17
 Hey everyone, I decided to take the time to add some quality of life features that were requested.
 

--- a/Thunderstore/README.md
+++ b/Thunderstore/README.md
@@ -101,6 +101,7 @@ Also, the bot only checks for the keywords anywhere in the message, for example,
 </br>**follow me** - The bot will move to follow you
 </br>**lead the way** - The bot will go to search for scrap on its own
 </br>**change suit** - The bot will change its suit to the suit you are wearing
+</br>**drop your held item** - The bot will drop its held item. If the bot is not holding anything, it will swap to the next item in its inventory.
 </br>Please note that you must be in chat range for the bot to hear you. If you are too far away, the bot will not respond to your command.
 If both you and the bot have a walkie-talkie, you can use the command in the chat and the bot will respond to it.
 </br>Please note that these are also voice commands, but they require you to only say the word unlike how they work as said in the chat.

--- a/Utils/Helpers/WeaponInfo.cs
+++ b/Utils/Helpers/WeaponInfo.cs
@@ -142,10 +142,10 @@ namespace LethalBots.Utils.Helpers
             FootstepSurface[] footstepSurfaces = StartOfRound.Instance.footstepSurfaces;
             RaycastHit[] raycastHits = Physics.SphereCastAll(ray, radius, maxRange, hitMask, QueryTriggerInteraction.Collide);
             List<RaycastHit> orderdHitList = raycastHits.OrderBy((RaycastHit x) => x.distance).ToList();
-            for (int i = 0; i < raycastHits.Length; i++)
+            for (int i = 0; i < orderdHitList.Count; i++)
             {
                 // Check if we hit a wall!
-                var hitInfo = raycastHits[i];
+                var hitInfo = orderdHitList[i];
                 if (hitInfo.transform.gameObject.layer == 8 || hitInfo.transform.gameObject.layer == 11)
                 {
                     if (hitInfo.collider.isTrigger)
@@ -199,10 +199,18 @@ namespace LethalBots.Utils.Helpers
         /// <param name="weapon">The weapon the bot is using</param>
         /// <param name="currentEnemy">The enemy the bot is attempting to hit</param>
         /// <param name="enemyCollider">The collider of the enemy the bot is attepting to hit</param>
+        /// <param name="canHitTarget">Does the bot believe it can hit <paramref name="currentEnemy"/></param>
         /// <param name="setSkipCooldown">This is a delegate function passed in by <see cref="FightEnemyState.weaponAttackCoroutine"/> to allow you to skip setting the attack cooldown.<br/> This is for cases where you want to use your own cooldown.</param>
         /// <returns></returns>
-        public virtual IEnumerator AttackWithWeapon(PlayerControllerB lethalBotController, GrabbableObject weapon, EnemyAI currentEnemy, Collider? enemyCollider, Action<bool> setSkipCooldown)
+        public virtual IEnumerator AttackWithWeapon(PlayerControllerB lethalBotController, GrabbableObject weapon, EnemyAI currentEnemy, Collider? enemyCollider, bool canHitTarget, Action<bool> setSkipCooldown)
         {
+            // Will we hit our target?
+            if (!canHitTarget)
+            {
+                yield return null;
+                yield break;
+            }
+
             weapon.UseItemOnClient(true);
             yield return null;
             // holdButtonUse is true for the shovel!

--- a/Utils/Items/Weapons/ShotgunInfo.cs
+++ b/Utils/Items/Weapons/ShotgunInfo.cs
@@ -136,8 +136,15 @@ namespace LethalBots.Utils.Items.Weapons
             return false;
         }
 
-        public override IEnumerator AttackWithWeapon(PlayerControllerB lethalBotController, GrabbableObject weapon, EnemyAI currentEnemy, Collider? enemyCollider, Action<bool> setSkipCooldown)
+        public override IEnumerator AttackWithWeapon(PlayerControllerB lethalBotController, GrabbableObject weapon, EnemyAI currentEnemy, Collider? enemyCollider, bool canHitTarget, Action<bool> setSkipCooldown)
         {
+            // Will we hit our target?
+            if (!canHitTarget)
+            {
+                yield return null;
+                yield break;
+            }
+
             if (weapon is ShotgunItem shotgun)
             {
                 // Can't fire, we are reloading!

--- a/Utils/Items/Weapons/ShovelInfo.cs
+++ b/Utils/Items/Weapons/ShovelInfo.cs
@@ -16,11 +16,7 @@ namespace LethalBots.Utils.Items.Weapons
 
         public override float GetWeaponAttackInterval(GrabbableObject weapon)
         {
-            if (weapon is Shovel)
-            {
-                return 0.78f; // Speed for shovels
-            }
-            return base.GetWeaponAttackInterval(weapon);
+            return 0.78f; // Speed for shovels
         }
 
         public override void GetWeaponAttackInfo(GrabbableObject weapon, PlayerControllerB lethalBotController, out Ray ray, out float maxFOV, out float radius, out float maxRange, out LayerMask hitMask)

--- a/Utils/Items/Weapons/ZapGunInfo.cs
+++ b/Utils/Items/Weapons/ZapGunInfo.cs
@@ -81,8 +81,15 @@ namespace LethalBots.Utils.Items.Weapons
             return false;
         }
 
-        public override IEnumerator AttackWithWeapon(PlayerControllerB lethalBotController, GrabbableObject weapon, EnemyAI currentEnemy, Collider? enemyCollider, Action<bool> setSkipCooldown)
+        public override IEnumerator AttackWithWeapon(PlayerControllerB lethalBotController, GrabbableObject weapon, EnemyAI currentEnemy, Collider? enemyCollider, bool canHitTarget, Action<bool> setSkipCooldown)
         {
+            // Will we hit our target?
+            if (!canHitTarget)
+            {
+                yield return null;
+                yield break;
+            }
+
             if (weapon is PatcherTool patcherTool)
             {
                 Transform shockingTarget = lethalBotController.shockingTarget;


### PR DESCRIPTION
Back again with a not so minor update. I made some requested changes to the Quota system. I also updated the bot's Usual Scrap support as well! Oh and fixed some bugs, as always.

- Added QuotaType config to allow users to change how the bot quota system decides how many bots to keep in the lobby
- Introduced "drop held item" chat command for bots
- Added support for Sledgehammer and Blowtorch from Usual Scrap
- Updated Usual Scrap revive logic to be up to date with its new changes
- Fixed some issues with the player count being desynced. (This also happend if you disconnected and opened another save file.
- Fixed some potentially null ref errors
- Improved the Bot Weapon API. THIS INCLUDES BREAKING CHANGES. WeaponInfo.AttackWithWeapon has a new parameter and will always be called, even if the bot doesn't believe it can hit its target.